### PR TITLE
Removed from the doc string

### DIFF
--- a/src/ansys/units/units.py
+++ b/src/ansys/units/units.py
@@ -131,8 +131,6 @@ class Units(object):
             SI unit string representation of the quantity.
         si_multiplier : float, None
             SI multiplier of the unit string.
-        si_offset : float
-            SI offset of the unit string.
 
         Returns
         -------


### PR DESCRIPTION
si_offset is not a parameter and does not belong in the parameter section of the doc string.

si_offset has been removed from the doc string.