### PR TITLE
Refactor/eliminate quantity type

### DIFF
--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -40,7 +40,6 @@ class Quantity(float):
         units=None,
         quantity_map=None,
         dimensions: ansunits.Dimensions = None,
-        _type_hint=None,
     ):
         if (
             (units and quantity_map)
@@ -75,7 +74,6 @@ class Quantity(float):
         units=None,
         quantity_map=None,
         dimensions: ansunits.Dimensions = None,
-        _type_hint=None,
     ):
         if (
             (units and quantity_map)
@@ -176,7 +174,7 @@ class Quantity(float):
         """Dimensions."""
         return self._unit.dimensions
 
-    def to(self, to_units: [str, any]) -> "Quantity":
+    def to(self, to_units: str | ansunits.Unit) -> "Quantity":
         """
         Perform quantity conversions.
 
@@ -198,9 +196,7 @@ class Quantity(float):
 
         # Retrieve all SI required SI data and perform conversion
         _, si_multiplier, si_offset = si_data(to_units)
-        print(self.si_value)
         new_value = (self.si_value / si_multiplier) - si_offset
-        print(new_value)
 
         new_obj = Quantity(value=new_value, units=to_units)
 

--- a/src/ansys/units/unit.py
+++ b/src/ansys/units/unit.py
@@ -38,11 +38,13 @@ class Unit:
             self._name = units
             dimensions = self._units_to_dim(units=units)
             self._dimensions = ansunits.Dimensions(dimensions)
+            if not self._dimensions.dimensions:
+                self._name = ""
         elif dimensions:
             self._dimensions = dimensions
             self._name = self._dim_to_units(dimensions=dimensions, unit_sys=unit_sys)
         else:
-            self._name = units or ""
+            self._name = ""
             self._dimensions = ansunits.Dimensions()
 
         if not config:

--- a/src/ansys/units/unit.py
+++ b/src/ansys/units/unit.py
@@ -26,23 +26,20 @@ class Unit:
 
         if not config:
             config = self._get_config(self._name)
-        if "type" not in config:
-            config.update({"type": self._get_config(self._name)["type"]})
-        for key in config:
-            setattr(self, f"_{key}", config[key])
+        if config:
+            for key in config:
+                setattr(self, f"_{key}", config[key])
 
-        dimensions = ansunits.Dimensions(units=units)
-        self._dimensions = dimensions.dimensions
+        self._dimensions = ansunits.Dimensions(units=units)
 
     def _get_config(self, name: str) -> dict:
         if name in ansunits._fundamental_units:
             return ansunits._fundamental_units[name]
 
         if name in ansunits._derived_units:
-            type = {"type": ansunits._QuantityType.derived}
-            return dict(**type, **ansunits._derived_units[name])
+            return ansunits._derived_units[name]
 
-        return {"type": ansunits._QuantityType.composite}
+        return
 
     @property
     def name(self):

--- a/tests/lib_compare/test_temperature_units.py
+++ b/tests/lib_compare/test_temperature_units.py
@@ -36,15 +36,15 @@ def test_ansunits_distinguishes_temperature_from_difference():
     from ansys.units.quantity import Quantity
 
     t1 = Quantity(150.0, "C")
-    assert t1.type == "Temperature"
+    assert str(t1.dimensions) == "{'temperature': 1.0}"
     t2 = Quantity(100.0, "C")
-    assert t2.type == "Temperature"
+    assert str(t2.dimensions) == "{'temperature': 1.0}"
     td1 = t1 - t2
-    assert td1.type == "Temperature Difference"
+    assert str(td1.dimensions) == "{'temperature_difference': 1.0}"
     t3 = Quantity(1.0, "K")
     t4 = Quantity(2.0, "K")
     td2 = t4 - t3
-    assert td2.type == "Temperature Difference"
+    assert str(td2.dimensions) == "{'temperature_difference': 1.0}"
 
 
 # These next tests are completely debatable.
@@ -54,38 +54,24 @@ def test_ansunits_distinguishes_temperature_from_difference():
 # OTOH if you start asserting that -1 K has to be a temperature difference, you
 # can run into a bunch of other issues.
 def test_ansunits_automatically_creates_temperature_difference_from_negative_absolute_value():
-    from util import assert_rightly_but_fail, assert_wrongly
-
     from ansys.units.quantity import Quantity
 
     t = Quantity(-1.0, "K")
-    assert_wrongly(
-        t.type == "Temperature",
-        "test_ansunits_automatically_creates_temperature_difference_from_negative_absolute_value",
-    )
-    assert_rightly_but_fail(
-        t.type == "Temperature Difference",
-        "test_ansunits_automatically_creates_temperature_difference_from_negative_absolute_value",
-    )
+    assert str(t.dimensions) == "{'temperature_difference': 1.0}"
+    assert t.units == "delta_K"
+    assert t.value == -1.0
 
 
 # shortened from test_ansunits_automatically_creates_temperature_
 # difference_from_negative_absolute_value_based_on_relative_value
 # to test_ansunits_temperature_difference_from_negative_absolute_value_to_relative_value
 def test_ansunits_temperature_difference_from_negative_absolute_value_to_relative_value():
-    from util import assert_rightly_but_fail, assert_wrongly
-
     from ansys.units.quantity import Quantity
 
     t = Quantity(-274.0, "C")
-    assert_wrongly(
-        t.type == "Temperature",
-        "test_ansunits_temperature_difference_from_negative_absolute_value_to_relative_value",
-    )
-    assert_rightly_but_fail(
-        t.type == "Temperature Difference",
-        "test_ansunits_temperature_difference_from_negative_absolute_value_to_relative_value",
-    )
+    assert str(t.dimensions) == "{'temperature_difference': 1.0}"
+    assert t.units == "delta_C"
+    assert t.value == -274.0
 
 
 def test_ansunits_converts_temperature_correctly():
@@ -106,7 +92,7 @@ def test_ansunits_converts_temperature_difference_correctly():
     assert dK.value == -1.0
     assert dK.units == "delta_K"
 
-    tC = dK.to("C")
+    tC = dK.to("delta_C")
     assert tC.value == -1.0
     assert tC.units == "delta_C"
     assert float(tC) == -1.0
@@ -115,7 +101,7 @@ def test_ansunits_converts_temperature_difference_correctly():
     assert dK.value == 1.0
     assert dK.units == "delta_K"
 
-    tC = dK.to("C")
+    tC = dK.to("delta_C")
     assert tC.value == 1.0
     assert tC.units == "delta_C"
     assert float(tC) == 1.0

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -14,7 +14,6 @@ def test_properties_1():
     assert v.units == "m"
     assert v.si_value == 10.6
     assert v.si_units == "m"
-    assert v.type == "Length"
 
 
 def test_properties_2():
@@ -23,7 +22,6 @@ def test_properties_2():
     assert v.units == "ft s^-1"
     assert v.si_value == pytest.approx(0.30479999, DELTA)
     assert v.si_units == "m s^-1"
-    assert v.type == "Composite"
 
 
 def test_properties_3():
@@ -32,7 +30,6 @@ def test_properties_3():
     assert v.units == "farad"
     assert v.si_value == 1.0
     assert v.si_units == "kg^-1 m^-2 s^4 A^2"
-    assert v.type == "Derived"
 
 
 def test_value():
@@ -299,7 +296,7 @@ def test_to_33():
 def test_temperature_to():
     t1 = ansunits.Quantity(273.15, "K")
     t1C = t1.to("C")
-    assert t1C.type == "Temperature"
+    assert t1C.dimensions.dimensions == {3: 1}
     assert t1C.value == 0.0
     assert t1C.units == "C"
 
@@ -309,12 +306,12 @@ def test_temperature_difference_to_with_explicit_delta():
     t2 = ansunits.Quantity(2.0, "K")
     td1 = t2 - t1
     td1C = td1.to("delta_C")
-    assert td1C.type == "Temperature Difference"
+    assert td1C.dimensions.dimensions == {4: 1}
     assert td1C.value == 1.0
     assert td1C.units == "delta_C"
     td2 = t1 - t2
     td2C = td2.to("delta_C")
-    assert td2C.type == "Temperature Difference"
+    assert td2C.dimensions.dimensions == {4: 1}
     assert td2C.value == -1.0
     assert td2C.units == "delta_C"
 
@@ -323,13 +320,13 @@ def test_temperature_difference_to_with_implicit_delta():
     t1 = ansunits.Quantity(1.0, "K")
     t2 = ansunits.Quantity(2.0, "K")
     td1 = t2 - t1
-    td1C = td1.to("C")
-    assert td1C.type == "Temperature Difference"
+    td1C = td1.to("delta_C")
+    assert td1C.dimensions.dimensions == {4: 1}
     assert td1C.value == 1.0
     assert td1C.units == "delta_C"
     td2 = t1 - t2
-    td2C = td2.to("C")
-    assert td2C.type == "Temperature Difference"
+    td2C = td2.to("delta_C")
+    assert td2C.dimensions.dimensions == {4: 1}
     assert td2C.value == -1.0
     assert td2C.units == "delta_C"
 
@@ -340,11 +337,9 @@ def test_complex_temperature_difference_to():
     m = ansunits.Quantity(1.0, "kg")
     result = m * (t2 - t1)
     resultC1 = result.to("kg C")
-    assert resultC1.type == "Composite"
     assert resultC1.value == 1.0
     assert resultC1.units == "kg C"
     resultC2 = result.to("kg delta_C")
-    assert resultC2.type == "Composite"
     assert resultC2.value == 1.0
     assert resultC2.units == "kg delta_C"
 
@@ -459,6 +454,7 @@ def test_power():
     qtm = qt * 2
 
     assert qtm.value == 10.0
+    assert qtm.dimensions.dimensions == {}
     assert qtm.units == ""
 
 
@@ -535,15 +531,15 @@ def test_temp_1():
 
     kc = k.to("C")
     assert kc.value == -313.15
-    assert kc.units == "C"
+    assert kc.units == "delta_C"
 
     kc = k.to("R")
     assert kc.value == pytest.approx(-72.0, DELTA)
-    assert kc.units == "R"
+    assert kc.units == "delta_R"
 
     kc = k.to("F")
     assert kc.value == pytest.approx(-531.67, DELTA)
-    assert kc.units == "F"
+    assert kc.units == "delta_F"
 
 
 def test_temp_2():
@@ -689,54 +685,31 @@ def test_temp_inverse_2():
     assert float(f_inverse) == pytest.approx(3.5999999999999996, DELTA)
 
 
-def test_temp_type():
-    c0 = ansunits.Quantity(1.0, "C")
-    assert c0.type == "Temperature"
-
-    c1 = ansunits.Quantity(1.0, "J kg^-1 C^-1")
-    assert c1.type == "Composite"
-
-    c2 = ansunits.Quantity(1.0, "kg m^-3 s^-1 K^2")
-    assert c2.type == "Composite"
-
-    c4 = ansunits.Quantity(1.0, "F")
-    assert c4.type == "Temperature"
-
-    c6 = ansunits.Quantity(1.0, "F^1")
-    assert c6.type == "Composite"
-
-    c7 = ansunits.Quantity(1.0, "F^-1")
-    assert c7.type == "Composite"
-
-    c8 = ansunits.Quantity(1.0, "F^2")
-    assert c8.type == "Composite"
-
-
 def test_temp_difference():
     td1 = ansunits.Quantity(150.0, "delta_C")
-    assert td1.type == "Temperature Difference"
+    assert td1.dimensions.dimensions == {4: 1}
 
     td2 = ansunits.Quantity(100.0, "delta_C")
-    assert td2.type == "Temperature Difference"
+    assert td2.dimensions.dimensions == {4: 1}
 
     td = td1 - td2
-    assert td.type == "Temperature Difference"
+    assert td.dimensions.dimensions == {4: 1}
 
     td_m = td * 2
     assert td_m.units == "delta_K"
-    assert td_m.type == "Temperature Difference"
+    assert td_m.dimensions.dimensions == {4: 1}
 
     t1 = ansunits.Quantity(150.0, "C")
-    assert t1.type == "Temperature"
+    assert t1.dimensions.dimensions == {3: 1}
 
     t2 = ansunits.Quantity(100.0, "C")
-    assert t2.type == "Temperature"
+    assert t2.dimensions.dimensions == {3: 1}
 
     td = t1 - t2
-    assert td.type == "Temperature Difference"
+    assert td.dimensions.dimensions == {4: 1}
 
     td2 = t2 - t1
-    assert td2.type == "Temperature Difference"
+    assert td2.dimensions.dimensions == {4: 1}
 
     tc1 = ansunits.Quantity(100.0, "C")
     td1 = ansunits.Quantity(50.0, "C^-1")
@@ -778,43 +751,34 @@ def test_temp_diff_combined_divide():
 def test_core_temp():
     t1 = ansunits.Quantity(1.0, "K")
     assert float(t1) == 1.0
-    assert t1.type == "Temperature"
 
     t2 = ansunits.Quantity(2.0, "K")
     assert float(t2) == 2.0
-    assert t2.type == "Temperature"
 
     dt1 = t2 - t1
     assert float(dt1) == 1.0
-    assert dt1.type == "Temperature Difference"
 
     t3 = ansunits.Quantity(1.0, "C")
     assert float(t3) == 274.15
-    assert t3.type == "Temperature"
 
     t4 = ansunits.Quantity(2.0, "C")
     assert float(t4) == 275.15
-    assert t4.type == "Temperature"
 
     dt2 = t4 - t3
     assert float(dt2) == 1.0
-    assert dt2.type == "Temperature Difference"
+    assert dt2.dimensions.dimensions == {4: 1}
 
     invt1 = ansunits.Quantity(1.0, "K^-1")
     assert float(invt1) == 1.0
-    assert invt1.type == "Composite"
 
     dt3 = 1.0 / invt1
     assert float(dt3) == 1.0
-    assert dt1.type == dt2.type
 
     invt2 = ansunits.Quantity(1.0, "C^-1")
     assert float(invt2) == 1.0
-    assert invt2.type == "Composite"
 
     dt4 = 1.0 / invt2
     assert float(dt4) == 1.0
-    assert dt4.type == "Temperature"
 
 
 def test_temp_addition():
@@ -822,16 +786,15 @@ def test_temp_addition():
     t2 = ansunits.Quantity(50.0, "C")
 
     td = t1 - t2
-    assert td.type == "Temperature Difference"
+    assert td.units == "delta_C"
     assert float(td) == 100.0
-    assert td.units == "delta_K"
 
     kd = ansunits.Quantity(50.0, "delta_C")
     k = ansunits.Quantity(50.0, "K")
 
     t = k + kd
     assert float(t) == 100.0
-    assert t.type == "Temperature Difference"
+    assert t.units == "K"
 
 
 def test_unit_from_dimensions_1():
@@ -1071,7 +1034,7 @@ def test_compute_temp_unit():
     kb = ansunits.Quantity(1.382e-23, "J K^-1")
     t = ansunits.Quantity(2.0, "K")
     e = kb * t
-    assert e.type == "Composite"
+    assert e.dimensions.dimensions == {0: 1.0, 1: 2.0, 2: -2.0}
     assert e.units == "kg m^2 s^-2"
 
 
@@ -1080,5 +1043,5 @@ def test_unit_multiply_quantity():
     mass = ansunits.Quantity(10.0, ur.kg)
     mass_flow_rate = mass / ur.s
     assert mass_flow_rate.units == "kg s^-1"
-    assert mass_flow_rate.type == "Composite"
     assert mass_flow_rate.value == 10
+    assert mass_flow_rate.dimensions.dimensions == {0: 1.0, 2: -1.0}


### PR DESCRIPTION
Quantity no longer uses "type".

delta_temp is fully regulated using dimensions.

This will now pass:
```
t1 = ansunits.Quantity(1.0, "K")
t2 = ansunits.Quantity(2.0, "K")
m = ansunits.Quantity(1.0, "kg")
result = m * (t2 - t1)
result2 = result / m
assert str(result2.dimensions) == "{'temperature_difference': 1.0}"
```

