### PR TITLE
Some documentation clean-ups

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -21,6 +21,7 @@ help:
 
 # Customized clean due to examples gallery
 clean:
+	rm -rf build_errors.txt
 	rm -rf $(BUILDDIR)/*
 	rm -rf $(SOURCEDIR)/examples
 	find . -type d -name "_autosummary" -exec rm -rf {} +

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=source
 set BUILDDIR=_build
+set SPHINXOPTS=-j auto -w build_errors.txt -N -q -W --keep-going
 
 if "%1" == "" goto help
 if "%1" == "clean" goto clean
@@ -33,6 +34,7 @@ goto end
 rmdir /s /q %BUILDDIR% > /NUL 2>&1
 rmdir /s /q %SOURCEDIR%\examples > /NUL 2>&1
 for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
+del build_errors.txt > /NUL 2>&1
 goto end
 
 :help

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -15,10 +15,10 @@ Clone and install
 Clone and install the latest PyAnsys Units release in development mode with
 these commands:
 
-.. code::
+.. code:: console
 
     git clone https://github.com/ansys/pyansys-units.git
-    cd ansunits
+    cd pyansys-units
     pip install pip -U
     pip install -e .
 
@@ -27,9 +27,9 @@ Build documentation
 Build the PyAnsys Units documentation locally by running these commands in the
 root directory of the repository:
 
-.. code::
+.. code:: console
 
-    pip install -r requirements/requirements_doc.txt
+    pip install -e .[doc]
     cd doc
     make html
 
@@ -40,7 +40,7 @@ directory into a web browser.
 You can clear all HTML files from the ``_builds/html`` directory with
 this command:
 
-.. code::
+.. code:: console
 
     make clean
 
@@ -57,13 +57,13 @@ PyAnsys Units is compliant with the `PyAnsys coding style
 `pre-commit <https://pre-commit.com/>`_ to check the code style. You can install
 and activate this tool with these commands:
 
-.. code:: bash
+.. code:: console
 
    python -m pip install pre-commit
    pre-commit install
 
 You can then directly execute ``pre-commit`` with this command:
 
-.. code:: bash
+.. code:: console
 
     pre-commit run --all-files --show-diff-on-failure

--- a/doc/source/user_guide/temperature.rst
+++ b/doc/source/user_guide/temperature.rst
@@ -4,9 +4,9 @@
 Temperature & Change of Temperature
 ===================================
 
-The default temperature units are kelvin, celsius, rankine and fahrenheit these are
-used as K, C, R and F. For each temperature unit there is a change of temperature unit
-which is prefixed with ``delta_``.
+PyAnsys Units supports temperature units in Kelvin (K), Celsius (C), Rankine (R)
+and Fahrenheit (F). For each temperature unit there is a change of temperature
+unit which is prefixed with ``delta_``.
 
 Conversion is handled naturally through arithmetic operations:
 
@@ -27,7 +27,8 @@ Conversion is handled naturally through arithmetic operations:
     delta_K_ad_delta_K = delta_K + delta_K  # (10, delta_K)
     delta_K_sb_delta_K = delta_K - delta_K  # (0, delta_K)
 
-A negative absolute value for any temperature will be assumed as a change in temperature.
+Negative absolute values for any temperature are instantiated as a change in
+temperature.
 
 .. code:: python
 

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -7,22 +7,37 @@ from ansys.units.utils import si_data
 
 class Quantity(float):
     """
-    A physical quantity using a real value and units.
+    A class which contains a physical quantity's value and associated units.
 
-    All instances of this class are converted to the base SI unit system
-    to have consistency in arithmetic operations.
+    The value and units provided on initialization are internally converted into
+    SI units to facilitate consistent computation with other quantities.
 
-    Methods
-    -------
-    to()
-        Convert to a given unit string.
+    Parameters
+    ----------
+    value : int | float
+        Real value of the quantity.
+    units : str, Unit, optional
+        Initializes the quantity's units using a string or ``Unit`` instance.
+    quantity_map : dict, optional
+        Initializes the quantity's units using the quantity map.
+    dimensions : Dimensions, optional
+        Initializes the quantity's units in SI using a ``Dimensions`` instance.
+
+    Attributes
+    ----------
+    value
+    units
+    si_value
+    si_units
+    dimensions
+    is_dimensionless
     """
 
     def __new__(
         cls,
         value,
         units=None,
-        quantity_map=None,
+        quantity_map: dict = None,
         dimensions: ansunits.Dimensions = None,
     ):
         if (
@@ -56,21 +71,9 @@ class Quantity(float):
         self,
         value,
         units=None,
-        quantity_map=None,
+        quantity_map: dict = None,
         dimensions: ansunits.Dimensions = None,
     ):
-        """
-        Parameters
-        ----------
-        value : int | float
-            Real value of the quantity.
-        units : str, Unit, optional
-            Unit string representation of the quantity.
-        quantity_map : dict, optional
-            Quantity map representation of the quantity.
-        dimensions : Dimensions, optional
-            Dimensions representation of the quantity.
-        """
         if (
             (units and quantity_map)
             or (units and dimensions)
@@ -173,12 +176,12 @@ class Quantity(float):
 
     @property
     def dimensions(self):
-        """Dimensions."""
+        """Base dimensions."""
         return self._unit.dimensions
 
     @property
     def is_dimensionless(self):
-        """Dimensions."""
+        """True if the quantity is dimensionless."""
         return not bool(self._unit.dimensions.dimensions)
 
     def to(self, to_units: [str, any]) -> "Quantity":


### PR DESCRIPTION
- Fixed documentation bit in the contributing guide.
- Aligned the windows and *nix makefiles
- Tidied up the Quantity documentation.  It's required to put the `__init__` parameters into the docstring for the class, and I included the "Attribtues" section so that they are all documented in their own heading.  See the section on documenting classes here:

https://numpydoc.readthedocs.io/en/latest/format.html#class-docstring