### PR TITLE
Drop dependency on python 3.8

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: ansys/actions/build-wheelhouse@v4
         with:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
       fail-fast: false
     steps:
       - uses: ansys/actions/tests-pytest@v4

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
     steps:
       - uses: ansys/actions/build-wheelhouse@v4
         with:
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: ansys/actions/tests-pytest@v4

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.9'
   DOCUMENTATION_CNAME: 'units.docs.pyansys.com'
   LIBRARY_NAME: 'ansys-units'
   LIBRARY_NAMESPACE: 'ansys.units'

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@a
 Installation
 ------------
 
-The ``ansys.units`` package supports Python 3.9 through Python 3.12 on Windows
+The ``ansys.units`` package supports Python 3.9 through Python 3.11 on Windows
 and Linux.
 
 

--- a/README.rst
+++ b/README.rst
@@ -66,7 +66,7 @@ To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@a
 Installation
 ------------
 
-The ``ansys.units`` package supports Python 3.8 through Python 3.11 on Windows
+The ``ansys.units`` package supports Python 3.9 through Python 3.12 on Windows
 and Linux.
 
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ============
 
-The ``ansys-units`` package supports Python 3.9 through Python 3.12 on Windows
+The ``ansys-units`` package supports Python 3.9 through Python 3.11 on Windows
 and Linux.
 
 Install the package

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ============
 
-The ``ansys-units`` package supports Python 3.8 through Python 3.11 on Windows
+The ``ansys-units`` package supports Python 3.9 through Python 3.12 on Windows
 and Linux.
 
 Install the package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ name = "ansys-units"
 version = "0.1.0"
 description = "Pythonic interface for units, unit systems, and unit conversions."
 readme = "README.rst"
-requires-python = ">=3.8,<4"
+requires-python = ">=3.9,<4"
 license = {file = "LICENSE"}
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
 maintainers = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
@@ -18,10 +18,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,6 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
 ]
 
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ basepython =
     py38: python3.8
     py39: python3.9
     py310: python3.10
+    py311: python3.11
+    py312: python3.12
     py: python3
     {style,tests,doc}: python3
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,6 @@ basepython =
     py39: python3.9
     py310: python3.10
     py311: python3.11
-    py312: python3.12
     py: python3
     {style,tests,doc}: python3
 setenv =


### PR DESCRIPTION
We are dropping python 3.8 as of now and later we can include 3.12