### PR TITLE
Unit system construction and copy. FIXED

### DIFF
--- a/examples/00-pyunits/basic_usage.py
+++ b/examples/00-pyunits/basic_usage.py
@@ -169,32 +169,47 @@ pas.units  # >>> "Pa s"
 ###############################################################################
 # Instantiate unit systems
 # ~~~~~~~~~~~~~~~~~~~~~~~~
-# You can instantiate unit systems using one of two methods:
+# You can instantiate unit systems using a few methods:
 #
 # - Custom units
 # - Predefined unit systems
+# - Copy from a preexisting unit system
+# - Combinations of these
 
 # Custom units
 
-sys_units = ["kg", "m", "s", "K", "delta_K", "radian", "mol", "cd", "A", "sr"]
-sys = ansunits.UnitSystem(name="sys", base_units=sys_units)
+dims = ansunits.BaseDimensions
+sys_units = {dims.MASS: "slug", dims.LENGTH: "ft"}
+sys = ansunits.UnitSystem(base_units=sys_units, unit_sys="SI")
 
-sys.name  # >>> "sys"
-sys.base_units  # >>> ["kg", "m", "s", "K", "delta_K", "radian", "mol", "cd", "A", "sr"]
+sys.base_units  # >>> ["slug", "ft", "s", "K", "delta_K", "radian", "mol", "cd", "A", "sr"]
 
 # Predefined unit systems
 
 cgs = ansunits.UnitSystem(unit_sys="CGS")
 
-cgs.name  # >>> "cgs"
 cgs.base_units  # >>> ['g', 'cm', 's', 'K', "delta_K", 'radian', 'mol', 'cd', 'A', 'sr']
+
+# Copy from a preexisting unit system
+
+cgs2 = ansunits.UnitSystem(copy_from=cgs)
+
+cgs2.base_units  # >>> ['g', 'cm', 's', 'K', "delta_K", 'radian', 'mol', 'cd', 'A', 'sr']
+
+# Combinations of these
+
+sys_units = {dims.MASS: "slug", dims.LENGTH: "ft", dims.ANGLE: "degree"}
+cgs_modified = ansunits.UnitSystem(base_units=sys_units, copy_from=cgs)
+
+cgs_modified.base_units  # >>> ['slug', 'ft', 's', 'K', "delta_K", 'degree', 'mol', 'cd', 'A', 'sr']
+
 
 ###############################################################################
 # Create a unit system independently
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # You can create a unit system independently and apply it to quantities.
 
-si = ansunits.UnitSystem(unit_sys="SI")
+si = ansunits.UnitSystem()
 fps = ansunits.Quantity(value=11.2, units="ft s^-1")
 
 mps = si.convert(fps)

--- a/src/ansys/units/__init__.py
+++ b/src/ansys/units/__init__.py
@@ -18,11 +18,8 @@ from ansys.units._constants import (  # noqa: F401
     _QuantityType,
     _unit_systems,
 )
-from ansys.units.dimensions import (  # noqa: F401
-    BaseDimensions,
-    Dimensions,
-    DimensionsError,
-)
+from ansys.units.base_dimensions import BaseDimensions
+from ansys.units.dimensions import Dimensions, DimensionsError  # noqa: F401
 from ansys.units.map import QuantityMap, QuantityMapError  # noqa: F401
 from ansys.units.quantity import Quantity, QuantityError  # noqa: F401
 from ansys.units.systems import UnitSystem, UnitSystemError  # noqa: F401

--- a/src/ansys/units/base_dimensions.py
+++ b/src/ansys/units/base_dimensions.py
@@ -1,0 +1,34 @@
+"""Provides the ``BaseDimensions`` class."""
+from enum import Enum
+
+
+class BaseDimensions(Enum):
+    """
+    Supplies all valid base dimensions used in dimensional analysis.
+
+    Used as dictionary keys for defining a `Dimensions` object.
+
+    Attributes
+    ----------
+    MASS
+    LENGTH
+    TIME
+    TEMPERATURE
+    TEMPERATURE_DIFFERENCE
+    ANGLE
+    CHEMICAL_AMOUNT
+    LIGHT
+    CURRENT
+    SOLID_ANGLE
+    """
+
+    MASS = 0
+    LENGTH = 1
+    TIME = 2
+    TEMPERATURE = 3
+    TEMPERATURE_DIFFERENCE = 4
+    ANGLE = 5
+    CHEMICAL_AMOUNT = 6
+    LIGHT = 7
+    CURRENT = 8
+    SOLID_ANGLE = 9

--- a/src/ansys/units/cfg.yaml
+++ b/src/ansys/units/cfg.yaml
@@ -41,38 +41,38 @@ multipliers:
 
 unit_systems:
   SI:
-    - kg
-    - m
-    - s
-    - K
-    - delta_K
-    - radian
-    - mol
-    - cd
-    - A
-    - sr
+    MASS: kg
+    LENGTH: m
+    TIME: s
+    TEMPERATURE: K
+    TEMPERATURE_DIFFERENCE: delta_K
+    ANGLE: radian
+    CHEMICAL_AMOUNT: mol
+    LIGHT: cd
+    CURRENT: A
+    SOLID_ANGLE: sr
   CGS:
-    - g
-    - cm
-    - s
-    - K
-    - delta_K
-    - radian
-    - mol
-    - cd
-    - A
-    - sr
+    MASS: g
+    LENGTH: cm
+    TIME: s
+    TEMPERATURE: K
+    TEMPERATURE_DIFFERENCE: delta_K
+    ANGLE: radian
+    CHEMICAL_AMOUNT: mol
+    LIGHT: cd
+    CURRENT: A
+    SOLID_ANGLE: sr
   BT:
-    - slug
-    - ft
-    - s
-    - R
-    - delta_R
-    - radian
-    - slugmol
-    - cd
-    - A
-    - sr
+    MASS: slug
+    LENGTH: ft
+    TIME: s
+    TEMPERATURE: R
+    TEMPERATURE_DIFFERENCE: delta_R
+    ANGLE: radian
+    CHEMICAL_AMOUNT: slugmol
+    LIGHT: cd
+    CURRENT: A
+    SOLID_ANGLE: sr
 
 # Base Units
 # -----------------

--- a/src/ansys/units/dimensions.py
+++ b/src/ansys/units/dimensions.py
@@ -1,51 +1,22 @@
-"""Provides the ``Dimensions`` and ``BaseDimensions`` class."""
-from enum import Enum
-from typing import Optional
+"""Provides the ``Dimensions`` class."""
+from typing import Union
 
-
-class BaseDimensions(Enum):
-    """
-    Supplies all valid base dimensions used in dimensional analysis.
-
-    Used as dictionary keys for defining a `Dimensions` object.
-
-    Attributes
-    ----------
-    MASS
-    LENGTH
-    TIME
-    TEMPERATURE
-    TEMPERATURE_DIFFERENCE
-    ANGLE
-    CHEMICAL_AMOUNT
-    LIGHT
-    CURRENT
-    SOLID_ANGLE
-    """
-
-    MASS = 0
-    LENGTH = 1
-    TIME = 2
-    TEMPERATURE = 3
-    TEMPERATURE_DIFFERENCE = 4
-    ANGLE = 5
-    CHEMICAL_AMOUNT = 6
-    LIGHT = 7
-    CURRENT = 8
-    SOLID_ANGLE = 9
+import ansys.units as ansunits
 
 
 class Dimensions:
     """
-    A class which contains the base unit information.
+    A composite dimension (or simply dimensions) composed from an arbitrary number of
+    fundamental dimensions, where each fundamental dimension is a pair consisting of
+    base dimension and exponent.
 
-    A dictionary of ``BaseDimensions`` and power is required
+    A dictionary of ``BaseDimensions`` and exponent is required
     for a non-dimensionless object.
 
     Parameters
     ----------
     dimensions_container : dict, optional
-        Dictionary of {``BaseDimensions``: power, ...}.
+        Dictionary of {``BaseDimensions``: exponent, ...}.
 
     Attributes
     ----------
@@ -54,21 +25,12 @@ class Dimensions:
 
     def __init__(
         self,
-        dimensions_container: Optional[BaseDimensions] = None,
+        dimensions_container: dict[ansunits.BaseDimensions, Union[int, float]] = None,
     ):
-        """
-        Create a ``Dimensions`` object from a dictionary of ``BaseDimensions`` and
-        power. Default is dimensionless.
-
-        Parameters
-        ----------
-        dimensions_container : dict, optional
-            Dictionary of {``BaseDimensions``: power, ...}.
-        """
         dimensions_container = dimensions_container or {}
         self._dimensions = dimensions_container.copy()
         for x, y in dimensions_container.items():
-            if not isinstance(x, BaseDimensions):
+            if not isinstance(x, ansunits.BaseDimensions):
                 raise DimensionsError.INCORRECT_DIMENSIONS()
             if y == 0:
                 del self._dimensions[x]
@@ -116,8 +78,8 @@ class Dimensions:
 
     def __eq__(self, other):
         temp_dim = self / other
-        temp = BaseDimensions.TEMPERATURE
-        temp_diff = BaseDimensions.TEMPERATURE_DIFFERENCE
+        temp = ansunits.BaseDimensions.TEMPERATURE
+        temp_diff = ansunits.BaseDimensions.TEMPERATURE_DIFFERENCE
         if temp in temp_dim._dimensions and temp_diff in temp_dim._dimensions:
             if temp_dim._dimensions[temp] == -temp_dim._dimensions[temp_diff]:
                 del temp_dim._dimensions[temp_diff]

--- a/src/ansys/units/map.py
+++ b/src/ansys/units/map.py
@@ -9,7 +9,7 @@ class QuantityMap(object):
     Parameters
     ----------
     quantity_map : dict
-        Dictionary containing quantity map units and powers.
+        Dictionary containing quantity map units and exponents.
 
     Attributes
     ----------
@@ -38,8 +38,8 @@ class QuantityMap(object):
             Unit object representation of the quantity map.
         """
         base_unit = ansunits.Unit()
-        for term, power in quantity_map.items():
-            base_unit *= ansunits.Unit(ansunits._api_quantity_map[term]) ** power
+        for term, exponent in quantity_map.items():
+            base_unit *= ansunits.Unit(ansunits._api_quantity_map[term]) ** exponent
 
         return base_unit
 

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -1,5 +1,7 @@
 """Provides the ``Quantity`` class."""
-from typing import Optional
+from __future__ import annotations
+
+from typing import Optional, Union
 
 import ansys.units as ansunits
 
@@ -119,7 +121,7 @@ class Quantity(float):
         if not isinstance(__value, Quantity) and not self.is_dimensionless:
             raise QuantityError.INCOMPATIBLE_VALUE(__value)
 
-    def _temp_precheck(self, units, op: str = None) -> Optional[str]:
+    def _temp_precheck(self, units: ansunits.Unit, op: str = None) -> Optional[str]:
         """
         Validate units for temperature differences.
 
@@ -176,7 +178,7 @@ class Quantity(float):
         """True if the quantity is dimensionless."""
         return not bool(self._unit.dimensions.dimensions)
 
-    def to(self, to_units: [str, any]) -> "Quantity":
+    def to(self, to_units: Union[ansunits.Unit, str]) -> "Quantity":
         """
         Perform quantity conversions.
 

--- a/src/ansys/units/systems.py
+++ b/src/ansys/units/systems.py
@@ -1,4 +1,8 @@
 """Provides the ``UnitSystem`` class."""
+from __future__ import annotations
+
+from typing import Union
+
 import ansys.units as ansunits
 
 
@@ -8,16 +12,15 @@ class UnitSystem:
 
     Parameters
     ----------
-    name: str, optional
-        Custom name associated with a user-defined unit system.
-    base_units: list, optional
-        Custom units associated with a user-defined unit system.
+    base_units: dict, optional
+        Units mapped to base dimensions types.
     unit_sys: str, optional
         Predefined unit system.
+    copy_from: UnitSystem
+        Make a copy of a unit system.
 
     Attributes
     ----------
-    name
     base_units
     MASS
     LENGTH
@@ -31,34 +34,29 @@ class UnitSystem:
     SOLID_ANGLE
     """
 
-    def __init__(self, name: str = None, base_units: list = None, unit_sys: str = None):
-        if name and unit_sys or base_units and unit_sys:
-            raise UnitSystemError.EXCESSIVE_PARAMETERS()
-
-        if base_units:
-            if len(set(base_units)) != len(ansunits.BaseDimensions):
-                raise UnitSystemError.BASE_UNITS_LENGTH(len(base_units))
-
-            self._name = name
-            self._base_units = base_units
-
+    def __init__(
+        self,
+        base_units: dict[ansunits.BaseDimensions, Union[ansunits.Unit, str]] = None,
+        unit_sys: str = None,
+        copy_from: ansunits.UnitSystem = None,
+    ):
+        if copy_from:
+            self._units = copy_from._units
         else:
             if not unit_sys:
                 unit_sys = "SI"
             if unit_sys not in ansunits._unit_systems:
                 raise UnitSystemError.INVALID_UNIT_SYS(unit_sys)
+            else:
+                self._units = ansunits._unit_systems[unit_sys].copy()
 
-            self._name = unit_sys
-            self._base_units = ansunits._unit_systems[unit_sys]
+        if base_units:
+            for unit_type, unit in base_units.items():
+                self._units[unit_type.name] = unit
 
-        for unit in self._base_units:
-            if not isinstance(unit, ansunits.Unit):
-                unit = ansunits.Unit(unit)
-
-            if unit.name not in ansunits._base_units:
-                raise UnitSystemError.NOT_BASE_UNIT(unit)
-
-            setattr(self, f"_{unit._type}", unit)
+        for unit_type in ansunits.BaseDimensions:
+            unit = self._units[unit_type.name]
+            self._set_type(unit_type=unit_type, unit=unit)
 
     def convert(self, quantity: ansunits.Quantity) -> ansunits.Quantity:
         """
@@ -78,17 +76,50 @@ class UnitSystem:
 
         return quantity.to(to_units=new_unit)
 
-    @property
-    def name(self):
-        """Name associated with the unit system."""
-        return self._name
+    def update(
+        self, base_units: dict[ansunits.BaseDimensions : Union[ansunits.Unit, str]]
+    ):
+        """
+        Change the units of the unit system.
+
+        Parameters
+        ----------
+        base_units: dict, obj
+            Units mapped to base dimensions types.
+        """
+        for unit_type, unit in base_units.items():
+            self._set_type(unit_type=unit_type, unit=unit)
+
+    def _set_type(
+        self, unit_type: ansunits.BaseDimensions, unit: Union[ansunits.Unit, str]
+    ):
+        """
+        Checks that the unit is compatible with the unit type before being set.
+
+        Parameters
+        ----------
+        unit_type: obj
+            Unit system type slot for the new unit.
+        unit: obj
+            The unit to be assigned.
+        """
+        if not isinstance(unit, ansunits.Unit):
+            unit = ansunits.Unit(unit)
+
+        if unit.name not in ansunits._base_units:
+            raise UnitSystemError.NOT_BASE_UNIT(unit)
+
+        if unit._type != unit_type.name:
+            raise UnitSystemError.WRONG_UNIT_TYPE(unit, unit_type)
+
+        setattr(self, f"_{unit_type.name}", unit)
 
     @property
     def base_units(self):
         """Units associated with the unit system."""
         _base_units = []
-        for type in ansunits.BaseDimensions:
-            unit = getattr(self, f"_{type.name}")
+        for unit_type in ansunits.BaseDimensions:
+            unit = getattr(self, f"_{unit_type.name}")
             _base_units.append(unit.name)
         return _base_units
 
@@ -97,50 +128,105 @@ class UnitSystem:
         """Mass unit of the unit system."""
         return self._MASS
 
+    @MASS.setter
+    def MASS(self, new_unit):
+        self._set_type(unit_type=ansunits.BaseDimensions.MASS, unit=new_unit)
+
     @property
     def LENGTH(self):
         """Length unit of the unit system."""
         return self._LENGTH
+
+    @LENGTH.setter
+    def LENGTH(self, new_unit):
+        self._set_type(unit_type=ansunits.BaseDimensions.LENGTH, unit=new_unit)
 
     @property
     def TIME(self):
         """Time unit of the unit system."""
         return self._TIME
 
+    @TIME.setter
+    def TIME(self, new_unit):
+        self._set_type(unit_type=ansunits.BaseDimensions.TIME, unit=new_unit)
+
     @property
     def TEMPERATURE(self):
         """Temperature unit of the unit system."""
         return self._TEMPERATURE
+
+    @TEMPERATURE.setter
+    def TEMPERATURE(self, new_unit):
+        self._set_type(unit_type=ansunits.BaseDimensions.TEMPERATURE, unit=new_unit)
 
     @property
     def TEMPERATURE_DIFFERENCE(self):
         """Temperature unit of the unit system."""
         return self._TEMPERATURE_DIFFERENCE
 
+    @TEMPERATURE_DIFFERENCE.setter
+    def TEMPERATURE_DIFFERENCE(self, new_mass):
+        self._set_type(
+            unit_type=ansunits.BaseDimensions.TEMPERATURE_DIFFERENCE, unit=new_mass
+        )
+
     @property
     def ANGLE(self):
         """Angle unit of the unit system."""
         return self._ANGLE
+
+    @ANGLE.setter
+    def ANGLE(self, new_mass):
+        self._set_type(unit_type=ansunits.BaseDimensions.ANGLE, unit=new_mass)
 
     @property
     def CHEMICAL_AMOUNT(self):
         """Chemical Amount unit of the unit system."""
         return self._CHEMICAL_AMOUNT
 
+    @CHEMICAL_AMOUNT.setter
+    def CHEMICAL_AMOUNT(self, new_mass):
+        self._set_type(unit_type=ansunits.BaseDimensions.CHEMICAL_AMOUNT, unit=new_mass)
+
     @property
     def LIGHT(self):
         """Light unit of the unit system."""
         return self._LIGHT
+
+    @LIGHT.setter
+    def LIGHT(self, new_mass):
+        self._set_type(unit_type=ansunits.BaseDimensions.LIGHT, unit=new_mass)
 
     @property
     def CURRENT(self):
         """Current unit of the unit system."""
         return self._CURRENT
 
+    @CURRENT.setter
+    def CURRENT(self, new_mass):
+        self._set_type(unit_type=ansunits.BaseDimensions.CURRENT, unit=new_mass)
+
     @property
     def SOLID_ANGLE(self):
         """Solid Angle unit of the unit system."""
         return self._SOLID_ANGLE
+
+    @SOLID_ANGLE.setter
+    def SOLID_ANGLE(self, new_mass):
+        self._set_type(unit_type=ansunits.BaseDimensions.SOLID_ANGLE, unit=new_mass)
+
+    def __repr__(self):
+        units = {}
+        for unit_type in ansunits.BaseDimensions:
+            unit = getattr(self, f"_{unit_type.name}")
+            units.update({unit_type.name: unit.name})
+        return str(units)
+
+    def __eq__(self, other_sys):
+        for attr, value in self.__dict__.items():
+            if getattr(other_sys, attr) != value:
+                return False
+        return True
 
 
 class UnitSystemError(ValueError):
@@ -148,19 +234,6 @@ class UnitSystemError(ValueError):
 
     def __init__(self, err):
         super().__init__(err)
-
-    @classmethod
-    def EXCESSIVE_PARAMETERS(cls):
-        return cls(
-            "UnitSystem only accepts one of the following parameters: "
-            "(name, base_units) or (unit_sys)."
-        )
-
-    @classmethod
-    def BASE_UNITS_LENGTH(cls, len):
-        return cls(
-            f"The `base_units` argument must contain 10 unique units, currently there are {len}."
-        )
 
     @classmethod
     def NOT_BASE_UNIT(cls, unit):
@@ -172,3 +245,9 @@ class UnitSystemError(ValueError):
     @classmethod
     def INVALID_UNIT_SYS(cls, sys):
         return cls(f"`{sys}` is not a supported unit system.")
+
+    @classmethod
+    def WRONG_UNIT_TYPE(cls, unit, unit_type):
+        return cls(
+            f"The unit `{unit.name}` is incompatible with unit system type: `{unit_type.name}`"
+        )

--- a/tests/lib_compare/test_angle_units.py
+++ b/tests/lib_compare/test_angle_units.py
@@ -24,7 +24,7 @@ def test_pint_angles_are_dimensionless():
 
 
 def test_pyunits_angles_have_angle_dimensions():
-    from ansys.units.dimensions import BaseDimensions
+    from ansys.units import BaseDimensions
     from ansys.units.quantity import Quantity
 
     radian = Quantity(1.0, "radian")

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -458,7 +458,7 @@ def test_rdiv():
     assert 2.0 / float(q1) == 0.2
 
 
-def test_power():
+def test_exponent():
     qt = ansunits.Quantity(5.0, "m^0")
     qtm = qt * 2
 

--- a/tests/test_systems.py
+++ b/tests/test_systems.py
@@ -4,52 +4,107 @@ import ansys.units as ansunits
 
 
 def test_pre_defined_unit_system():
+    ur = ansunits.UnitRegistry()
     us = ansunits.UnitSystem(unit_sys="SI")
-    assert us.name == "SI"
-    assert us.base_units == [
-        "kg",
-        "m",
-        "s",
-        "K",
-        "delta_K",
-        "radian",
-        "mol",
-        "cd",
-        "A",
-        "sr",
-    ]
+    assert us.MASS == ur.kg
+    assert us.LENGTH == ur.m
+    assert us.TIME == ur.s
+    assert us.TEMPERATURE == ur.K
+    assert us.TEMPERATURE_DIFFERENCE == ur.delta_K
+    assert us.ANGLE == ur.radian
+    assert us.CHEMICAL_AMOUNT == ur.mol
+    assert us.LIGHT == ur.cd
+    assert us.CURRENT == ur.A
+    assert us.SOLID_ANGLE == ur.sr
+
+
+def test_copy():
+    us = ansunits.UnitSystem(unit_sys="BT")
+    us1 = ansunits.UnitSystem(copy_from=us)
+    assert us1 == us
+
+
+def test_update():
+    dims = ansunits.BaseDimensions
+    ur = ansunits.UnitRegistry()
+    us = ansunits.UnitSystem(unit_sys="SI")
+    base_units = {
+        dims.MASS: "slug",
+        dims.LENGTH: ur.ft,
+        dims.TIME: ur.s,
+        dims.TEMPERATURE: ur.R,
+        dims.TEMPERATURE_DIFFERENCE: ur.delta_R,
+        dims.ANGLE: ur.degree,
+        dims.CHEMICAL_AMOUNT: ur.slugmol,
+        dims.LIGHT: ur.cd,
+        dims.CURRENT: ur.A,
+        dims.SOLID_ANGLE: ur.sr,
+    }
+    us.update(base_units=base_units)
+    assert us.MASS == ur.slug
+    assert us.LENGTH == ur.ft
+    assert us.TIME == ur.s
+    assert us.TEMPERATURE == ur.R
+    assert us.TEMPERATURE_DIFFERENCE == ur.delta_R
+    assert us.ANGLE == ur.degree
+    assert us.CHEMICAL_AMOUNT == ur.slugmol
+    assert us.LIGHT == ur.cd
+    assert us.CURRENT == ur.A
+    assert us.SOLID_ANGLE == ur.sr
+
+
+def test_eq():
+    us1 = ansunits.UnitSystem(unit_sys="BT")
+    us2 = ansunits.UnitSystem()
+    us3 = ansunits.UnitSystem(unit_sys="SI")
+    assert (us1 == us2) == False
+    assert us2 == us3
+
+
+def test_single_set():
+    ur = ansunits.UnitRegistry()
+    us = ansunits.UnitSystem(unit_sys="SI")
+    us.MASS = ur.slug
+    us.LENGTH = ur.ft
+    us.TEMPERATURE = ur.R
+    us.TEMPERATURE_DIFFERENCE = ur.delta_R
+    us.ANGLE = ur.degree
+    us.CHEMICAL_AMOUNT = ur.slugmol
+    assert us.MASS == ur.slug
+    assert us.LENGTH == ur.ft
+    assert us.TEMPERATURE == ur.R
+    assert us.TEMPERATURE_DIFFERENCE == ur.delta_R
+    assert us.ANGLE == ur.degree
+    assert us.CHEMICAL_AMOUNT == ur.slugmol
 
 
 def test_custom_unit_system():
+    dims = ansunits.BaseDimensions
     ur = ansunits.UnitRegistry()
     us = ansunits.UnitSystem(
-        name="sys",
-        base_units=[
-            ur.slug,
-            ur.ft,
-            ur.s,
-            ur.R,
-            ur.delta_R,
-            ur.radian,
-            ur.slugmol,
-            ur.cd,
-            ur.A,
-            ur.sr,
-        ],
+        base_units={
+            dims.MASS: ur.slug,
+            dims.LENGTH: ur.ft,
+            dims.TIME: ur.s,
+            dims.TEMPERATURE: ur.R,
+            dims.TEMPERATURE_DIFFERENCE: ur.delta_R,
+            dims.ANGLE: ur.radian,
+            dims.CHEMICAL_AMOUNT: ur.slugmol,
+            dims.LIGHT: ur.cd,
+            dims.CURRENT: ur.A,
+            dims.SOLID_ANGLE: ur.sr,
+        }
     )
-    assert us.name == "sys"
-    assert us.base_units == [
-        "slug",
-        "ft",
-        "s",
-        "R",
-        "delta_R",
-        "radian",
-        "slugmol",
-        "cd",
-        "A",
-        "sr",
-    ]
+    assert us.MASS == ur.slug
+    assert us.LENGTH == ur.ft
+    assert us.TIME == ur.s
+    assert us.TEMPERATURE == ur.R
+    assert us.TEMPERATURE_DIFFERENCE == ur.delta_R
+    assert us.ANGLE == ur.radian
+    assert us.CHEMICAL_AMOUNT == ur.slugmol
+    assert us.LIGHT == ur.cd
+    assert us.CURRENT == ur.A
+    assert us.SOLID_ANGLE == ur.sr
 
 
 def test_conversion():
@@ -60,10 +115,7 @@ def test_conversion():
     assert q2.value == 0.6852176585679174
     assert q2.units == "slug ft s"
 
-    us2 = ansunits.UnitSystem(
-        name="sys",
-        base_units=["kg", "m", "s", "K", "delta_K", "radian", "mol", "cd", "A", "sr"],
-    )
+    us2 = ansunits.UnitSystem(unit_sys="SI")
     q3 = ansunits.Quantity(4, "slug cm s")
 
     q4 = us2.convert(q3)
@@ -71,130 +123,51 @@ def test_conversion():
     assert q4.units == "kg m s"
 
 
-def test_errors():
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us1 = ansunits.UnitSystem(
-            name="sys",
-            base_units=["slug", "ft", "s", "R", "radian", "slugmol", "cd", "A", "sr"],
-            unit_sys="BT",
-        )
+def test_not_base_unit_init():
+    with pytest.raises(ansunits.UnitSystemError):
+        dims = ansunits.BaseDimensions
+        ur = ansunits.UnitRegistry()
+        us1 = ansunits.UnitSystem(base_units={dims.LENGTH: ur.N})
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us2 = ansunits.UnitSystem(
-            name="sys",
-            base_units=[
-                "slug",
-                "ft",
-                "s",
-                "R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-                "cd",
-                "A",
-                "sr",
-            ],
-        )
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us3 = ansunits.UnitSystem(
-            name="sys",
-            base_units=[
-                "slug",
-                "ft",
-                "N",
-                "R",
-                "delta_R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-            ],
-        )
+def test_not_base_unit_update():
+    with pytest.raises(ansunits.UnitSystemError):
+        dims = ansunits.BaseDimensions
+        ur = ansunits.UnitRegistry()
+        us = ansunits.UnitSystem(unit_sys="SI")
+        base_units = {dims.MASS: ur.N}
+        us.update(base_units=base_units)
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us4 = ansunits.UnitSystem(
-            name="sys",
-            base_units=[
-                "slug",
-                "slug",
-                "s",
-                "R",
-                "delta_R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-            ],
-        )
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us5 = ansunits.UnitSystem(
-            name="sys",
-            base_units=["m", "ft", "s", "R", "radian", "slugmol", "cd", "A", "sr"],
-        )
+def test_not_base_unit_update():
+    with pytest.raises(ansunits.UnitSystemError):
+        dims = ansunits.BaseDimensions
+        ur = ansunits.UnitRegistry()
+        us = ansunits.UnitSystem(unit_sys="SI")
+        base_units = {dims.MASS: ur.N}
+        us.update(base_units=base_units)
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us6 = ansunits.UnitSystem(unit_sys="Standard")
 
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us7 = ansunits.UnitSystem(
-            name="us6",
-            base_units=[
-                "kg s^-1",
-                "ft",
-                "s",
-                "R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-            ],
-        )
-
-    with pytest.raises(ansunits.UnitSystemError) as e_info:
-        us6 = ansunits.UnitSystem(
-            name="us6",
-            base_units=[
-                "kg s^-1",
-                "ft",
-                "s",
-                "R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-            ],
-        )
+def test_invalid_unit_sys():
+    with pytest.raises(ansunits.UnitSystemError):
+        us2 = ansunits.UnitSystem(unit_sys="Standard")
 
 
 def test_error_messages():
-    e1 = ansunits.UnitSystemError.EXCESSIVE_PARAMETERS()
-    expected_str = (
-        "UnitSystem only accepts one of the following parameters: "
-        "(name, base_units) or (unit_sys)."
-    )
-    assert str(e1) == expected_str
-
-    e2 = ansunits.UnitSystemError.BASE_UNITS_LENGTH(11)
-    expected_str = "The `base_units` argument must contain 10 unique units, currently there are 11."
-    assert str(e2) == expected_str
-
-    e3 = ansunits.UnitSystemError.NOT_BASE_UNIT(ansunits.Unit("kg s^-1"))
+    e1 = ansunits.UnitSystemError.NOT_BASE_UNIT(ansunits.Unit("kg s^-1"))
     expected_str = (
         "`kg s^-1` is not a base unit. To use `kg s^-1`, add it to the "
         "`base_units` table within the cfg.yaml file."
     )
-    assert str(e3) == expected_str
+    assert str(e1) == expected_str
 
-    e4 = ansunits.UnitSystemError.INVALID_UNIT_SYS("ham sandwich")
-    assert str(e4) == "`ham sandwich` is not a supported unit system."
+    e2 = ansunits.UnitSystemError.INVALID_UNIT_SYS("ham sandwich")
+    assert str(e2) == "`ham sandwich` is not a supported unit system."
+
+    e3 = ansunits.UnitSystemError.WRONG_UNIT_TYPE(
+        unit=ansunits.Unit("ft"), unit_type=ansunits.BaseDimensions.MASS
+    )
+    assert str(e3) == "The unit `ft` is incompatible with unit system type: `MASS`"
 
 
 def test_si_properties():

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -66,22 +66,22 @@ def test_unit_pow():
 
 def test_unit_sys_list():
     dims = ansunits.BaseDimensions
+    ur = ansunits.UnitRegistry()
     slug = ansunits.Unit(
         dimensions=ansunits.Dimensions({dims.MASS: 1}),
         unit_sys=ansunits.UnitSystem(
-            name="sys",
-            base_units=[
-                "slug",
-                "ft",
-                "s",
-                "R",
-                "delta_R",
-                "radian",
-                "slugmol",
-                "cd",
-                "A",
-                "sr",
-            ],
+            base_units={
+                dims.MASS: ur.slug,
+                dims.LENGTH: ur.ft,
+                dims.TIME: ur.s,
+                dims.TEMPERATURE: ur.R,
+                dims.TEMPERATURE_DIFFERENCE: ur.delta_R,
+                dims.ANGLE: ur.radian,
+                dims.CHEMICAL_AMOUNT: ur.slugmol,
+                dims.LIGHT: ur.cd,
+                dims.CURRENT: ur.A,
+                dims.SOLID_ANGLE: ur.sr,
+            },
         ),
     )
     assert slug.name == "slug"


### PR DESCRIPTION
1.	`base_units` must be a dict. Only requires the changes from the unit system used. Default is "SI".
2.	Can now copy a unit system with:
```
us = UnitSystem()
new_us = UnitSystem(copy_from= us)
```
3.	Can now update a unit system with:
```
ur = unitRegistry()
us = UnitSystem()
us.update(base_units = {dims.MASS: "slug", dims.LENGTH: ur.ft})
```
4.	repr returns a dict with `{unit_type: unit name,...}` for each unit.
5.	Test were updated.
6.	Units can be set individually.` us.LENGTH = "m"` as long as the unit given is compatible with that unit type.
7.	A unit will repr as all the unit info.
8.	UnitSystems are no longer named.
