### PR TITLE
Changed in to inch.

### DIFF
--- a/src/ansys/units/cfg.yaml
+++ b/src/ansys/units/cfg.yaml
@@ -122,6 +122,10 @@ base_units:
     type: LENGTH
     si_scaling_factor: 0.0254
     si_offset: 0
+  in:
+    type: LENGTH
+    si_scaling_factor: 0.0254
+    si_offset: 0
   s:
     type: TIME
     si_scaling_factor: 1

--- a/src/ansys/units/cfg.yaml
+++ b/src/ansys/units/cfg.yaml
@@ -118,7 +118,7 @@ base_units:
     type: LENGTH
     si_scaling_factor: 0.30479999999999996
     si_offset: 0
-  in:
+  inch:
     type: LENGTH
     si_scaling_factor: 0.0254
     si_offset: 0
@@ -241,7 +241,7 @@ derived_units:
     composition: lbm ft s^-2
     factor: 1
   psi:
-    composition: lbf in^-2
+    composition: lbf inch^-2
     factor: 1
   lbf:
     composition: slug ft s^-2

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -434,7 +434,7 @@ def testing_units_to_dimensions():
     dim_test("daPa", {dims.MASS: 1.0, dims.LENGTH: -1.0, dims.TIME: -2.0})
     dim_test("MPa", {dims.MASS: 1.0, dims.LENGTH: -1.0, dims.TIME: -2.0})
     dim_test("kPa^2", {dims.MASS: 2.0, dims.LENGTH: -2.0, dims.TIME: -4.0})
-    dim_test("slug in^-1 s^-1", {dims.MASS: 1.0, dims.LENGTH: -1.0, dims.TIME: -1.0})
+    dim_test("slug inch^-1 s^-1", {dims.MASS: 1.0, dims.LENGTH: -1.0, dims.TIME: -1.0})
     dim_test("radian", {dims.ANGLE: 1.0})
     dim_test(
         "ohm", {dims.MASS: 1.0, dims.LENGTH: 2.0, dims.TIME: -3.0, dims.CURRENT: -2.0}
@@ -456,7 +456,7 @@ def testing_multipliers():
     from_to("dm^3", "m^3")
     from_to("m s^-1", "cm s^-1")
     from_to("N", "dyne")
-    from_to("m^2", "in^2")
+    from_to("m^2", "inch^2")
     from_to("degree s^-1", "radian s^-1")
     from_to("radian s^-1", "degree s^-1")
     from_to("Pa", "lb m s^-2 ft^-2")

--- a/tests/test_unit_registry.py
+++ b/tests/test_unit_registry.py
@@ -18,6 +18,11 @@ def test_default_units():
     assert N.name == "N"
     assert N._composition == "kg m s^-2"
     assert N.si_scaling_factor == 1
+    inch = ur.inch
+    assert inch.name == "inch"
+    assert inch._type == "LENGTH"
+    assert inch.si_scaling_factor == 0.0254
+    assert inch.si_offset == 0
 
 
 def test_custom_yaml():


### PR DESCRIPTION
Switched the 'in' name to 'inch' to avoid keyword problems with 'in'.