### PR TITLE
Preferred Units

### DIFF
--- a/doc/source/api/quantity.rst
+++ b/doc/source/api/quantity.rst
@@ -32,3 +32,6 @@ Quantity
 
 .. autoexception:: ansys.units.quantity.NumPyRequired
    :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.RequiresUniqueDimensions
+   :show-inheritance:

--- a/examples/00-pyunits/basic_usage.py
+++ b/examples/00-pyunits/basic_usage.py
@@ -269,3 +269,20 @@ meters_per_second = feet_per_second.convert(si)
 
 meters_per_second.value  # >>> 3.4137599999999995
 meters_per_second.units  # >>> "m s^-1"
+
+
+###############################################################################
+# Using preferred units
+# ~~~~~~~~~~~~~~~~~~~~~
+# Specify a list of units that quantities will automatically convert to.
+
+Quantity.preferred_units(units=["J"])
+
+torque = Quantity(1, quantity_map={"Torque": 1})
+torque  # >>> Quantity (1.0, "J")
+
+ten_N = Quantity(10, units="N")
+ten_m = Quantity(10, units="m")
+
+joules = ten_N * ten_m
+joules  # >>> Quantity (100.0, "J")

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -190,8 +190,9 @@ class Quantity:
         """
         Add or remove preferred units.
 
-        Quantities will automatically be converted to preferred units during
-        instantiation.
+        Quantities are automatically converted to preferred units when the
+        quantity is initialized. Conversion is always carried out if the base
+        units are consistent with the preferred units.
 
         Parameters
         ----------

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -463,3 +463,13 @@ class InvalidFloatUsage(FloatingPointError):
         super().__init__(
             "Only dimensionless quantities and angles can be used as a float."
         )
+
+
+class RequiresUniqueDimensions(ValueError):
+    """Provides the error when two units with the same dimensions are added to the
+    chosen units."""
+
+    def __init__(self, unit, other_unit):
+        super().__init__(
+            f"For '{unit.name}' to be added '{other_unit.name}' must be removed."
+        )

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -17,11 +17,28 @@ from ansys.units.quantity import (  # InvalidFloatUsage,
     IncompatibleValue,
     InsufficientArguments,
     NumPyRequired,
+    RequiresUniqueDimensions,
     get_si_value,
 )
 from ansys.units.unit import IncorrectUnits
 
 DELTA = 1.0e-5
+
+
+def test_preferred_units():
+    Quantity.preferred_units(units=["J", "slug", "psi"])
+    assert Quantity._chosen_units == [Unit("J"), Unit("slug"), Unit("psi")]
+
+    with pytest.raises(RequiresUniqueDimensions):
+        Quantity.preferred_units(units=["kg"])
+
+    ten_N = Quantity(10, units="N")
+    ten_m = Quantity(10, units="m")
+
+    assert ten_N * ten_m == Quantity(100, units="J")
+
+    Quantity.preferred_units(units=["J", "slug", "psi"], remove=True)
+    assert Quantity._chosen_units == []
 
 
 def test_properties():
@@ -553,3 +570,6 @@ def test_error_messages():
 
     e3 = IncompatibleValue("radian")
     assert str(e3) == "`radian` is incompatible with the current quantity object."
+
+    e4 = RequiresUniqueDimensions(Unit("mm"), Unit("m"))
+    assert str(e4) == "For 'mm' to be added 'm' must be removed."

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -32,12 +32,28 @@ def test_preferred_units():
     with pytest.raises(RequiresUniqueDimensions):
         Quantity.preferred_units(units=["kg"])
 
+    Quantity.preferred_units(units=["slug"], remove=True)
+    Quantity.preferred_units(units=["kg"])
+    Quantity.preferred_units(units=["kg Pa"])
+
+    ten_pa = Quantity(10, units="Pa")
+    assert ten_pa.value == pytest.approx(0.0014503773773020918, DELTA)
+    assert ten_pa.units == Unit(units="psi")
+
+    ten_slug = Quantity(10, units="slug")
+    assert ten_slug.value == pytest.approx(145.93902937206367, DELTA)
+    assert ten_slug.units == Unit(units="kg")
+
+    assert (ten_slug * ten_pa).value == pytest.approx(1459.3902937206367, DELTA)
+    assert (ten_slug * ten_pa).units == Unit(units="kg Pa")
+
     ten_N = Quantity(10, units="N")
     ten_m = Quantity(10, units="m")
 
-    assert ten_N * ten_m == Quantity(100, units="J")
+    assert (ten_N * ten_m).value == pytest.approx(100, DELTA)
+    assert (ten_N * ten_m).units == Unit(units="J")
 
-    Quantity.preferred_units(units=["J", "slug", "psi"], remove=True)
+    Quantity.preferred_units(units=["J", "kg", "psi", "kg Pa"], remove=True)
     assert Quantity._chosen_units == []
 
 


### PR DESCRIPTION
Preferred units added.

Added a class method to condition preferred unit inputs.

Units can be added to the `Quantity._chosen_units` class variable. Any Quantity instantiated after will check these units. If the new unit can be converted, it well return with the chosen unit. 