### PR TITLE
More API documentation cleanup

### DIFF
--- a/doc/source/api/dimensions.rst
+++ b/doc/source/api/dimensions.rst
@@ -4,8 +4,11 @@
 Dimensions
 ==========
 
-.. automodule:: ansys.units.dimensions
+.. autoclass:: ansys.units.dimensions.Dimensions
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: __weakref__, __dict__, __init__, DimensionsError
+   :exclude-members:
+
+.. autoexception:: ansys.units.dimensions.IncorrectDimensions
+   :show-inheritance:

--- a/doc/source/api/quantity.rst
+++ b/doc/source/api/quantity.rst
@@ -4,8 +4,31 @@
 Quantity
 ========
 
-.. automodule:: ansys.units.quantity
+.. autoclass:: ansys.units.quantity.Quantity
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: __weakref__, __dict__, __init__, QuantityError
+   :exclude-members:
+
+.. autofunction:: ansys.units.quantity.get_si_value
+
+.. autoexception:: ansys.units.quantity.ExcessiveParameters
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.IncompatibleDimensions
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.IncompatibleQuantities
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.IncompatibleValue
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.InsufficientArguments
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.InvalidFloatUsage
+   :show-inheritance:
+
+.. autoexception:: ansys.units.quantity.NumPyRequired
+   :show-inheritance:

--- a/doc/source/api/systems.rst
+++ b/doc/source/api/systems.rst
@@ -4,8 +4,17 @@
 Unit systems
 ============
 
-.. automodule:: ansys.units.systems
+.. autoclass:: ansys.units.systems.UnitSystem
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: __weakref__, __dict__, __init__, UnitSystemError
+   :exclude-members:
+
+.. autoexception:: ansys.units.systems.IncorrectUnitType
+   :show-inheritance:
+
+.. autoexception:: ansys.units.systems.InvalidUnitSystem
+   :show-inheritance:
+
+.. autoexception:: ansys.units.systems.NotBaseUnit
+   :show-inheritance:

--- a/doc/source/api/unit.rst
+++ b/doc/source/api/unit.rst
@@ -4,8 +4,23 @@
 Unit
 ====
 
-.. automodule:: ansys.units.unit
+.. autoclass:: ansys.units.unit.Unit
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: __weakref__, __dict__, __init__, UnitError
+   :exclude-members:
+
+.. autoexception:: ansys.units.unit.IncorrectTemperatureUnits
+   :show-inheritance:
+
+.. autoexception:: ansys.units.unit.IncorrectUnits
+   :show-inheritance:
+
+.. autoexception:: ansys.units.unit.InconsistentDimensions
+   :show-inheritance:
+
+.. autoexception:: ansys.units.unit.UnconfiguredUnit
+   :show-inheritance:
+
+.. autoexception:: ansys.units.unit.UnknownMapItem
+   :show-inheritance:

--- a/doc/source/api/unit_registry.rst
+++ b/doc/source/api/unit_registry.rst
@@ -4,8 +4,11 @@
 Unit registry
 =============
 
-.. automodule:: ansys.units.unit_registry
+.. autoclass:: ansys.units.unit_registry.UnitRegistry
    :members:
    :show-inheritance:
    :undoc-members:
-   :exclude-members: __weakref__, __dict__, __init__
+   :exclude-members:
+
+.. autoexception:: ansys.units.unit_registry.UnitAlreadyRegistered
+   :show-inheritance:

--- a/requirements/requirements_tests.txt
+++ b/requirements/requirements_tests.txt
@@ -1,3 +1,0 @@
-pytest
-pytest-mock
-pytest-cov

--- a/src/ansys/units/dimensions.py
+++ b/src/ansys/units/dimensions.py
@@ -6,20 +6,6 @@ from typing import Union
 from ansys.units import BaseDimensions
 
 
-class IncorrectDimensions(ValueError):
-    """Provides the error when dimensions are not in dimension order."""
-
-    def __init__(self):
-        super().__init__("The `dimensions` key must be a 'BaseDimensions' object")
-
-
-class IncorrectSystem(ValueError):
-    """Provides the error when the given unit system is not a 'UnitSystem'."""
-
-    def __init__(self):
-        super().__init__("The system must be a 'UnitSystem' instance.")
-
-
 class Dimensions:
     """
     A representation of an arbitrary number of dimensions, where each dimension is a
@@ -122,3 +108,10 @@ class Dimensions:
 
     def __bool__(self):
         return bool(self._dimensions)
+
+
+class IncorrectDimensions(ValueError):
+    """Raised on initialization if a dimension is not of type ``BaseDimensions``."""
+
+    def __init__(self):
+        super().__init__("The `dimensions` key must be a 'BaseDimensions' object")

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -16,69 +16,6 @@ except ImportError:
     _array = None
 
 
-class ExcessiveParameters(ValueError):
-    """Provides the error when excessive parameters are provided."""
-
-    def __init__(self):
-        super().__init__(
-            "Quantity only accepts one of the following parameters: \
-            (units) or (quantity_map) or (dimensions)."
-        )
-
-
-class InsufficientArguments(ValueError):
-    """Provides the error when insufficient arguments are provided."""
-
-    def __init__(self):
-        super().__init__("Requires at least one 'value' or 'copy_from' argument.")
-
-
-class IncompatibleDimensions(ValueError):
-    """Provides the error when dimensions are incompatible."""
-
-    def __init__(self, from_unit, to_unit):
-        super().__init__(
-            f"`{from_unit.name}` and `{to_unit.name}` have incompatible dimensions."
-        )
-
-
-class IncompatibleValue(ValueError):
-    """Provides the error when an incompatible value is provided."""
-
-    def __init__(self, value):
-        super().__init__(f"`{value}` is incompatible with the current quantity object.")
-
-
-class IncompatibleQuantities(ValueError):
-    """Provides the error when quantities are incompatible."""
-
-    def __init__(self, q1, q2):
-        super().__init__(f"'{q1}' and '{q2}' are incompatible.")
-
-
-class NumPyRequired(ModuleNotFoundError):
-    """Provides the error when NumPy is unavailable."""
-
-    def __init__(self):
-        super().__init__("To use NumPy arrays and lists install NumPy.")
-
-
-class InvalidFloatUsage(FloatingPointError):
-    """Provides the error when float is unsupported for given type of quantity."""
-
-    def __init__(self):
-        super().__init__(
-            "Only dimensionless quantities and angles can be used as a float."
-        )
-
-
-def get_si_value(quantity: Quantity) -> float:
-    """The value in SI units."""
-    return float(
-        (quantity.value + quantity.units.si_offset) * quantity.units.si_scaling_factor
-    )
-
-
 class Quantity:
     """
     A class representing a physical quantity's value and associated units.
@@ -387,7 +324,7 @@ class Quantity:
         return Quantity(-self.value, self._unit)
 
     def validate_matching_dimensions(self, other):
-        """Validate dimensions of quantities."""
+        """Validates dimensions of quantities."""
         if isinstance(other, Quantity) and (self.dimensions != other.dimensions):
             raise IncompatibleDimensions(from_unit=self.units, to_unit=other.units)
         elif (
@@ -427,3 +364,66 @@ class Quantity:
 
     def __ne__(self, __value):
         return not self.__eq__(__value)
+
+
+def get_si_value(quantity: Quantity) -> float:
+    """Returns a quantity's value in SI units."""
+    return float(
+        (quantity.value + quantity.units.si_offset) * quantity.units.si_scaling_factor
+    )
+
+
+class ExcessiveParameters(ValueError):
+    """Raised when excessive parameters are provided."""
+
+    def __init__(self):
+        super().__init__(
+            "Quantity only accepts one of the following parameters: \
+            (units) or (quantity_map) or (dimensions)."
+        )
+
+
+class InsufficientArguments(ValueError):
+    """Raised when insufficient arguments are provided."""
+
+    def __init__(self):
+        super().__init__("Requires at least one 'value' or 'copy_from' argument.")
+
+
+class IncompatibleDimensions(ValueError):
+    """Raised when dimensions are incompatible."""
+
+    def __init__(self, from_unit, to_unit):
+        super().__init__(
+            f"`{from_unit.name}` and `{to_unit.name}` have incompatible dimensions."
+        )
+
+
+class IncompatibleValue(ValueError):
+    """Raised when an incompatible value is provided."""
+
+    def __init__(self, value):
+        super().__init__(f"`{value}` is incompatible with the current quantity object.")
+
+
+class IncompatibleQuantities(ValueError):
+    """Raised when quantities are incompatible."""
+
+    def __init__(self, q1, q2):
+        super().__init__(f"'{q1}' and '{q2}' are incompatible.")
+
+
+class NumPyRequired(ModuleNotFoundError):
+    """Raised when NumPy is unavailable."""
+
+    def __init__(self):
+        super().__init__("To use NumPy arrays and lists install NumPy.")
+
+
+class InvalidFloatUsage(FloatingPointError):
+    """Raised when float is unsupported for given type of quantity."""
+
+    def __init__(self):
+        super().__init__(
+            "Only dimensionless quantities and angles can be used as a float."
+        )

--- a/src/ansys/units/systems.py
+++ b/src/ansys/units/systems.py
@@ -4,32 +4,6 @@ from __future__ import annotations
 from ansys.units import BaseDimensions, _base_units, _unit_systems
 
 
-class NotBaseUnit(ValueError):
-    """Provides the error when the provided unit is unavailable in base units."""
-
-    def __init__(self, unit):
-        super().__init__(
-            f"`{unit}` is not a base unit. To use `{unit}`, add it to the "
-            "`base_units` table within the cfg.yaml file."
-        )
-
-
-class InvalidUnitSystem(ValueError):
-    """Provides the error when the provided unit system is unsupported."""
-
-    def __init__(self, sys):
-        super().__init__(f"`{sys}` is not a supported unit system.")
-
-
-class IncorrectUnitType(ValueError):
-    """Provides the error when the type of provided unit is incorrect."""
-
-    def __init__(self, unit, unit_type):
-        super().__init__(
-            f"The unit `{unit}` is incompatible with unit system type: `{unit_type.name}`"
-        )
-
-
 class UnitSystem:
     """
     A class representing base units for a unit system.
@@ -218,3 +192,29 @@ class UnitSystem:
             if getattr(other_sys, attr) != value:
                 return False
         return True
+
+
+class NotBaseUnit(ValueError):
+    """Raised when a unit system unit is not a configured base unit."""
+
+    def __init__(self, unit):
+        super().__init__(
+            f"`{unit}` is not a base unit. To use `{unit}`, add it to the "
+            "`base_units` table within the cfg.yaml file."
+        )
+
+
+class InvalidUnitSystem(ValueError):
+    """Raised when a unit system is initialized with an unsupported unit system."""
+
+    def __init__(self, sys):
+        super().__init__(f"`{sys}` is not a supported unit system.")
+
+
+class IncorrectUnitType(ValueError):
+    """Raised when a unit is provided that does not have a valid type of base unit."""
+
+    def __init__(self, unit, unit_type):
+        super().__init__(
+            f"The unit `{unit}` is incompatible with unit system type: `{unit_type.name}`"
+        )

--- a/src/ansys/units/unit.py
+++ b/src/ansys/units/unit.py
@@ -13,373 +13,6 @@ from ansys.units import (
 from ansys.units.systems import UnitSystem
 
 
-class InconsistentDimensions(ValueError):
-    """Provides the error when dimensions are inconsistent."""
-
-    def __init__(self):
-        super().__init__("Unit dimensions do not match given dimensions.")
-
-
-class UnconfiguredUnit(ValueError):
-    """Provides the error when the specified unit is unconfigured."""
-
-    def __init__(self, unit):
-        super().__init__(f"`{unit}` is an unconfigured unit.")
-
-
-class IncorrectUnits(ValueError):
-    """Provides the error when the specified units are incorrect."""
-
-    def __init__(self, unit1, unit2):
-        super().__init__(
-            f"'{unit1.si_units}' and '{unit2.si_units}' must match for this operation."
-        )
-
-
-class IncorrectTemperatureUnits(ValueError):
-    """Provides the error when two temperatures are added."""
-
-    def __init__(self, unit1, unit2):
-        super().__init__(
-            f"Either '{unit1.name}' or '{unit2.name}' must be a relative unit for "
-            f"this operation."
-        )
-
-
-class UnknownMapItem(ValueError):
-    """Provides the error when the specified quantity map is undefined in the yaml."""
-
-    def __init__(self, item):
-        super().__init__(f"`{item}` is not a valid quantity map item.")
-
-
-def get_config(name: str) -> dict:
-    """
-    Retrieve unit configuration from '_base_units' or '_derived_units'.
-
-    Parameters
-    ----------
-    name : str
-        Unit string.
-    Returns
-    -------
-    dict
-        Dictionary of extra unit information.
-    """
-    if name in _base_units:
-        return _base_units[name]
-    if name in _derived_units:
-        return _derived_units[name]
-
-
-def dim_to_units(
-    system: UnitSystem,
-    dimensions: Dimensions,
-) -> str:
-    """
-    Convert a dimensions list into a unit string.
-
-    Parameters
-    ----------
-    dimensions : Dimensions object
-        Instance of Dimension class.
-
-        system : UnitSystem object, optional
-            Unit system for dimensions list.
-            Default is SI units.
-
-        Returns
-        -------
-        str
-            Unit string.
-    """
-    if not system:
-        system = UnitSystem()
-
-    units = ""
-
-    for key, value in dimensions:
-        if value == 1:
-            units += f"{getattr(system, key.name)} "
-        elif value != 0.0:
-            value = int(value) if value % 1 == 0 else value
-            units += f"{getattr(system, key.name)}^{value} "
-
-    return units.strip()
-
-
-def units_to_dim(
-    units: str, exponent: float = None, dimensions: dict = None
-) -> dict[BaseDimensions : Union[int, float]]:
-    """
-    Convert a unit string into a Dimensions instance.
-
-    Parameters
-    ----------
-    units : str
-        Unit string.
-    Returns
-    -------
-    dict
-        Dimensions dictionary
-    """
-    exponent = exponent or 1.0
-    dimensions = dimensions or {}
-    # Split unit string into terms and parse data associated with individual terms
-    for term in units.split(" "):
-        _, unit_term, unit_term_exponent = filter_unit_term(term)
-        unit_term_exponent *= exponent
-        # retrieve data associated with base unit
-        if unit_term in _base_units:
-            idx = _base_units[unit_term]["type"]
-
-            if BaseDimensions[idx] in dimensions:
-                dimensions[BaseDimensions[idx]] += unit_term_exponent
-            else:
-                dimensions[BaseDimensions[idx]] = unit_term_exponent
-
-        # Retrieve derived unit composition unit string and SI factor.
-        if unit_term in _derived_units:
-            # Recursively parse composition unit string
-
-            dimensions = units_to_dim(
-                units=_derived_units[unit_term]["composition"],
-                exponent=unit_term_exponent,
-                dimensions=dimensions,
-            )
-
-    return dimensions
-
-
-def map_to_units(map: dict) -> str:
-    """
-    Convert a quantity map into a unit string.
-
-    Parameters
-    ----------
-    quantity_map : dict[str, int]
-        Quantity map to convert to a Unit.
-
-    Returns
-    -------
-    Unit
-        Unit object representation of the quantity map.
-    """
-    for key in map.keys():
-        if key not in _api_quantity_map:
-            raise UnknownMapItem(key)
-
-    base_unit = ""
-
-    for key, value in map.items():
-        terms = _api_quantity_map[key]
-        for term in terms.split(" "):
-            multiplier, base, exponent = filter_unit_term(term)
-
-            base_unit += f"{multiplier}{base}^{exponent*value} "
-
-    return condense(base_unit)
-
-
-def multiplier_check(unit_term: str) -> bool:
-    """
-    Check if a unit term contains a multiplier.
-
-    Parameters
-    ----------
-    unit_term : str
-        Unit term of the unit string.
-
-    Returns
-    -------
-    bool
-        ``True`` if the unit term contains a multiplier, ``False`` otherwise.
-    """
-    # Check if the unit term is not an existing base or derived unit.
-    return unit_term and not (
-        (unit_term in _base_units) or (unit_term in _derived_units)
-    )
-
-
-def si_map(unit_term: str) -> str:
-    """
-    Map unit to SI unit equivalent.
-
-    Parameters
-    ----------
-    unit_term : str
-        Unit term of the unit string.
-
-    Returns
-    -------
-    str
-        SI unit equivalent.
-    """
-    # Retrieve type associated with unit term
-    unit_term_type = _base_units[unit_term]["type"]
-
-    # Find SI unit with same type as unit term
-    for term, term_info in _base_units.items():
-        if (
-            term_info["type"] == unit_term_type
-            and term_info["si_scaling_factor"] == 1.0
-        ):
-            return term
-
-
-def condense(units=str) -> str:
-    """
-    Condense a unit string by collecting like terms.
-
-    Parameters
-    ----------
-    units : str
-        Unit string to simplify.
-
-    Returns
-    -------
-    str
-        Simplified unit string.
-    """
-    terms_and_exponents = {}
-    units = units.strip()
-
-    # Split unit string into terms and parse data associated with individual terms
-    for term in units.split(" "):
-        multiplier, unit_term, unit_term_exponent = filter_unit_term(term)
-        full_term = f"{multiplier}{unit_term}"
-        if full_term in terms_and_exponents:
-            terms_and_exponents[full_term] += unit_term_exponent
-        else:
-            terms_and_exponents[full_term] = unit_term_exponent
-    units = ""
-    # Concatenate unit string
-    for term, exponent in terms_and_exponents.items():
-        if not (exponent):
-            continue
-        if exponent == 1.0:
-            units += f"{term} "
-        else:
-            exponent = int(exponent) if exponent % 1 == 0 else exponent
-            units += f"{term}^{exponent} "
-
-    return units.rstrip()
-
-
-def filter_unit_term(unit_term: str) -> tuple:
-    """
-    Separate multiplier, base, and exponent from a unit term.
-
-    Parameters
-    ----------
-    unit_term : str
-        Unit term of the unit string.
-
-    Returns
-    -------
-    tuple
-        Tuple containing the multiplier, base, and exponent of the unit term.
-    """
-    multiplier = ""
-    exponent = 1.0
-
-    # strip exponent from unit term
-    if "^" in unit_term:
-        exponent = float(unit_term[unit_term.index("^") + 1 :])
-        unit_term = unit_term[: unit_term.index("^")]
-
-    base = unit_term
-
-    # strip multiplier and base from unit term
-    has_multiplier = multiplier_check(unit_term)
-    if has_multiplier:
-        for mult in _multipliers:
-            if unit_term.startswith(mult):
-                if not multiplier_check(unit_term[len(mult) :]):
-                    multiplier = mult
-                    base = unit_term[len(mult) :]
-                    break
-
-    # if we thought it had a multiplier, that's just because the string wasn't
-    # a known unit on its own. So if we can't actually find its multiplier then
-    # this string is an invalid unit string
-    if has_multiplier and not multiplier:
-        raise UnconfiguredUnit(unit_term)
-    return multiplier, base, exponent
-
-
-def si_data(
-    units: str,
-    exponent: float = None,
-    si_units: str = None,
-    si_scaling_factor: float = None,
-) -> tuple:
-    """
-    Compute the SI unit string, SI scaling factor, and SI offset.
-
-    Parameters
-    ----------
-    units : str
-        Unit string representation of the quantity.
-    exponent : float, None
-        exponent of the unit string.
-    si_units : str, None
-        SI unit string representation of the quantity.
-    si_scaling_factor : float, None
-        SI scaling factor of the unit string.
-
-    Returns
-    -------
-    tuple
-        Tuple containing the SI units, SI scaling factor, and SI offset.
-    """
-    # Initialize default values
-    units = units or " "
-    exponent = exponent or 1.0
-    si_units = si_units or ""
-    si_scaling_factor = si_scaling_factor or 1.0
-    si_offset = _base_units[units]["si_offset"] if units in _base_units else 0.0
-
-    # Split unit string into terms and parse data associated with individual terms
-    for term in units.split(" "):
-        unit_multiplier, unit_term, unit_term_exponent = filter_unit_term(term)
-
-        unit_term_exponent *= exponent
-
-        si_scaling_factor *= (
-            _multipliers[unit_multiplier] ** unit_term_exponent
-            if unit_multiplier
-            else 1.0
-        )
-
-        # Retrieve data associated with base unit
-        if unit_term in _base_units:
-            if unit_term_exponent == 1.0:
-                si_units += f" {si_map(unit_term)}"
-            elif unit_term_exponent != 0.0:
-                si_units += f" {si_map(unit_term)}^{unit_term_exponent}"
-
-            si_scaling_factor *= (
-                _base_units[unit_term]["si_scaling_factor"] ** unit_term_exponent
-            )
-
-        # Retrieve derived unit composition unit string and SI scaling factor
-        elif unit_term in _derived_units:
-            si_scaling_factor *= (
-                _derived_units[unit_term]["factor"] ** unit_term_exponent
-            )
-
-            # Recursively parse composition unit string
-            si_units, si_scaling_factor, _ = si_data(
-                units=_derived_units[unit_term]["composition"],
-                exponent=unit_term_exponent,
-                si_units=si_units,
-                si_scaling_factor=si_scaling_factor,
-            )
-
-    return condense(si_units), si_scaling_factor, si_offset
-
-
 class Unit:
     """
     A class containing the string name and dimensions of a unit.
@@ -436,11 +69,11 @@ class Unit:
             units = copy_from.name
 
         if map:
-            units = map_to_units(map=map)
+            units = _map_to_units(map=map)
 
         if units:
             self._name = units
-            _dimensions = units_to_dim(units=units)
+            _dimensions = _units_to_dim(units=units)
             self._dimensions = Dimensions(_dimensions)
             if dimensions and self._dimensions != dimensions:
                 raise InconsistentDimensions()
@@ -449,18 +82,18 @@ class Unit:
 
         elif dimensions:
             self._dimensions = dimensions
-            self._name = dim_to_units(dimensions=dimensions, system=system)
+            self._name = _dim_to_units(dimensions=dimensions, system=system)
         else:
             self._name = ""
             self._dimensions = Dimensions()
 
         if not config:
-            config = get_config(name=self._name)
+            config = _get_config(name=self._name)
         if config:
             for key in config:
                 setattr(self, f"_{key}", config[key])
 
-        self._si_units, self._si_scaling_factor, self._si_offset = si_data(
+        self._si_units, self._si_scaling_factor, self._si_offset = _si_data(
             units=self.name
         )
 
@@ -498,17 +131,17 @@ class Unit:
         new_units = ""
         if op == "**":
             for term in self.name.split(" "):
-                multiplier, base, exponent = filter_unit_term(term)
+                multiplier, base, exponent = _filter_unit_term(term)
                 exponent *= __value
                 new_units += f"{multiplier}{base}^{exponent} "
         if op == "/":
             new_units = self.name
             for term in __value.name.split(" "):
-                multiplier, base, exponent = filter_unit_term(term)
+                multiplier, base, exponent = _filter_unit_term(term)
                 new_units += f" {multiplier}{base}^{exponent*-1}"
         if op == "*":
             new_units = f"{self.name} {__value.name}"
-        return Unit(condense(new_units))
+        return Unit(_condense(new_units))
 
     def compatible_units(self) -> set[str]:
         """
@@ -672,3 +305,370 @@ class Unit:
 
     def __ne__(self, other_unit):
         return not self.__eq__(other_unit=other_unit)
+
+
+def _get_config(name: str) -> dict:
+    """
+    Retrieve unit configuration from '_base_units' or '_derived_units'.
+
+    Parameters
+    ----------
+    name : str
+        Unit string.
+    Returns
+    -------
+    dict
+        Dictionary of extra unit information.
+    """
+    if name in _base_units:
+        return _base_units[name]
+    if name in _derived_units:
+        return _derived_units[name]
+
+
+def _dim_to_units(
+    system: UnitSystem,
+    dimensions: Dimensions,
+) -> str:
+    """
+    Convert a dimensions list into a unit string.
+
+    Parameters
+    ----------
+    dimensions : Dimensions object
+        Instance of Dimension class.
+
+        system : UnitSystem object, optional
+            Unit system for dimensions list.
+            Default is SI units.
+
+        Returns
+        -------
+        str
+            Unit string.
+    """
+    if not system:
+        system = UnitSystem()
+
+    units = ""
+
+    for key, value in dimensions:
+        if value == 1:
+            units += f"{getattr(system, key.name)} "
+        elif value != 0.0:
+            value = int(value) if value % 1 == 0 else value
+            units += f"{getattr(system, key.name)}^{value} "
+
+    return units.strip()
+
+
+def _units_to_dim(
+    units: str, exponent: float = None, dimensions: dict = None
+) -> dict[BaseDimensions : Union[int, float]]:
+    """
+    Convert a unit string into a Dimensions instance.
+
+    Parameters
+    ----------
+    units : str
+        Unit string.
+    Returns
+    -------
+    dict
+        Dimensions dictionary
+    """
+    exponent = exponent or 1.0
+    dimensions = dimensions or {}
+    # Split unit string into terms and parse data associated with individual terms
+    for term in units.split(" "):
+        _, unit_term, unit_term_exponent = _filter_unit_term(term)
+        unit_term_exponent *= exponent
+        # retrieve data associated with base unit
+        if unit_term in _base_units:
+            idx = _base_units[unit_term]["type"]
+
+            if BaseDimensions[idx] in dimensions:
+                dimensions[BaseDimensions[idx]] += unit_term_exponent
+            else:
+                dimensions[BaseDimensions[idx]] = unit_term_exponent
+
+        # Retrieve derived unit composition unit string and SI factor.
+        if unit_term in _derived_units:
+            # Recursively parse composition unit string
+
+            dimensions = _units_to_dim(
+                units=_derived_units[unit_term]["composition"],
+                exponent=unit_term_exponent,
+                dimensions=dimensions,
+            )
+
+    return dimensions
+
+
+def _map_to_units(map: dict) -> str:
+    """
+    Convert a quantity map into a unit string.
+
+    Parameters
+    ----------
+    quantity_map : dict[str, int]
+        Quantity map to convert to a Unit.
+
+    Returns
+    -------
+    Unit
+        Unit object representation of the quantity map.
+    """
+    for key in map.keys():
+        if key not in _api_quantity_map:
+            raise UnknownMapItem(key)
+
+    base_unit = ""
+
+    for key, value in map.items():
+        terms = _api_quantity_map[key]
+        for term in terms.split(" "):
+            multiplier, base, exponent = _filter_unit_term(term)
+
+            base_unit += f"{multiplier}{base}^{exponent*value} "
+
+    return _condense(base_unit)
+
+
+def _multiplier_check(unit_term: str) -> bool:
+    """
+    Check if a unit term contains a multiplier.
+
+    Parameters
+    ----------
+    unit_term : str
+        Unit term of the unit string.
+
+    Returns
+    -------
+    bool
+        ``True`` if the unit term contains a multiplier, ``False`` otherwise.
+    """
+    # Check if the unit term is not an existing base or derived unit.
+    return unit_term and not (
+        (unit_term in _base_units) or (unit_term in _derived_units)
+    )
+
+
+def _si_map(unit_term: str) -> str:
+    """
+    Convert a unit into its SI equivalent.
+
+    Parameters
+    ----------
+    unit_term : str
+        Unit term of the unit string.
+
+    Returns
+    -------
+    str
+        SI unit equivalent.
+    """
+    # Retrieve type associated with unit term
+    unit_term_type = _base_units[unit_term]["type"]
+
+    # Find SI unit with same type as unit term
+    for term, term_info in _base_units.items():
+        if (
+            term_info["type"] == unit_term_type
+            and term_info["si_scaling_factor"] == 1.0
+        ):
+            return term
+
+
+def _condense(units=str) -> str:
+    """
+    Condense a unit string by collecting like terms.
+
+    Parameters
+    ----------
+    units : str
+        Unit string to simplify.
+
+    Returns
+    -------
+    str
+        Simplified unit string.
+    """
+    terms_and_exponents = {}
+    units = units.strip()
+
+    # Split unit string into terms and parse data associated with individual terms
+    for term in units.split(" "):
+        multiplier, unit_term, unit_term_exponent = _filter_unit_term(term)
+        full_term = f"{multiplier}{unit_term}"
+        if full_term in terms_and_exponents:
+            terms_and_exponents[full_term] += unit_term_exponent
+        else:
+            terms_and_exponents[full_term] = unit_term_exponent
+    units = ""
+    # Concatenate unit string
+    for term, exponent in terms_and_exponents.items():
+        if not (exponent):
+            continue
+        if exponent == 1.0:
+            units += f"{term} "
+        else:
+            exponent = int(exponent) if exponent % 1 == 0 else exponent
+            units += f"{term}^{exponent} "
+
+    return units.rstrip()
+
+
+def _filter_unit_term(unit_term: str) -> tuple:
+    """
+    Separate multiplier, base, and exponent from a unit term.
+
+    Parameters
+    ----------
+    unit_term : str
+        Unit term of the unit string.
+
+    Returns
+    -------
+    tuple
+        Tuple containing the multiplier, base, and exponent of the unit term.
+    """
+    multiplier = ""
+    exponent = 1.0
+
+    # strip exponent from unit term
+    if "^" in unit_term:
+        exponent = float(unit_term[unit_term.index("^") + 1 :])
+        unit_term = unit_term[: unit_term.index("^")]
+
+    base = unit_term
+
+    # strip multiplier and base from unit term
+    has_multiplier = _multiplier_check(unit_term)
+    if has_multiplier:
+        for mult in _multipliers:
+            if unit_term.startswith(mult):
+                if not _multiplier_check(unit_term[len(mult) :]):
+                    multiplier = mult
+                    base = unit_term[len(mult) :]
+                    break
+
+    # if we thought it had a multiplier, that's just because the string wasn't
+    # a known unit on its own. So if we can't actually find its multiplier then
+    # this string is an invalid unit string
+    if has_multiplier and not multiplier:
+        raise UnconfiguredUnit(unit_term)
+    return multiplier, base, exponent
+
+
+def _si_data(
+    units: str,
+    exponent: float = None,
+    si_units: str = None,
+    si_scaling_factor: float = None,
+) -> tuple:
+    """
+    Compute the SI unit string, SI scaling factor, and SI offset.
+
+    Parameters
+    ----------
+    units : str
+        Unit string representation of the quantity.
+    exponent : float, None
+        exponent of the unit string.
+    si_units : str, None
+        SI unit string representation of the quantity.
+    si_scaling_factor : float, None
+        SI scaling factor of the unit string.
+
+    Returns
+    -------
+    tuple
+        Tuple containing the SI units, SI scaling factor, and SI offset.
+    """
+    # Initialize default values
+    units = units or " "
+    exponent = exponent or 1.0
+    si_units = si_units or ""
+    si_scaling_factor = si_scaling_factor or 1.0
+    si_offset = _base_units[units]["si_offset"] if units in _base_units else 0.0
+
+    # Split unit string into terms and parse data associated with individual terms
+    for term in units.split(" "):
+        unit_multiplier, unit_term, unit_term_exponent = _filter_unit_term(term)
+
+        unit_term_exponent *= exponent
+
+        si_scaling_factor *= (
+            _multipliers[unit_multiplier] ** unit_term_exponent
+            if unit_multiplier
+            else 1.0
+        )
+
+        # Retrieve data associated with base unit
+        if unit_term in _base_units:
+            if unit_term_exponent == 1.0:
+                si_units += f" {_si_map(unit_term)}"
+            elif unit_term_exponent != 0.0:
+                si_units += f" {_si_map(unit_term)}^{unit_term_exponent}"
+
+            si_scaling_factor *= (
+                _base_units[unit_term]["si_scaling_factor"] ** unit_term_exponent
+            )
+
+        # Retrieve derived unit composition unit string and SI scaling factor
+        elif unit_term in _derived_units:
+            si_scaling_factor *= (
+                _derived_units[unit_term]["factor"] ** unit_term_exponent
+            )
+
+            # Recursively parse composition unit string
+            si_units, si_scaling_factor, _ = _si_data(
+                units=_derived_units[unit_term]["composition"],
+                exponent=unit_term_exponent,
+                si_units=si_units,
+                si_scaling_factor=si_scaling_factor,
+            )
+
+    return _condense(si_units), si_scaling_factor, si_offset
+
+
+class InconsistentDimensions(ValueError):
+    """Raised when units have inconsistent base dimensions."""
+
+    def __init__(self):
+        super().__init__("Unit dimensions do not match given dimensions.")
+
+
+class UnconfiguredUnit(ValueError):
+    """Raised when the specified unit is unconfigured."""
+
+    def __init__(self, unit):
+        super().__init__(f"`{unit}` is an unconfigured unit.")
+
+
+class IncorrectUnits(ValueError):
+    """Raised when the specified units are incorrect."""
+
+    def __init__(self, unit1, unit2):
+        super().__init__(
+            f"'{unit1.si_units}' and '{unit2.si_units}' must match for this operation."
+        )
+
+
+class IncorrectTemperatureUnits(ValueError):
+    """Raised when incompatible temperature dimensions are added."""
+
+    def __init__(self, unit1, unit2):
+        super().__init__(
+            f"Either '{unit1.name}' or '{unit2.name}' must be a relative unit for "
+            f"this operation."
+        )
+
+
+class UnknownMapItem(ValueError):
+    """Raised when a quantity mapping is undefined."""
+
+    def __init__(self, item):
+        super().__init__(f"`{item}` is not a valid quantity map item.")

--- a/src/ansys/units/unit_registry.py
+++ b/src/ansys/units/unit_registry.py
@@ -6,14 +6,6 @@ import yaml
 from ansys.units import Unit
 
 
-class UnitAlreadyRegistered(ValueError):
-    """Provides the error when the specified unit is trying to override a registered
-    unit."""
-
-    def __init__(self, name):
-        super().__init__(f"Unable to override `{name}` it has already been registered.")
-
-
 class UnitRegistry:
     """
     A representation of valid ``Unit`` instances.
@@ -72,3 +64,10 @@ class UnitRegistry:
     def __iter__(self):
         for item in self.__dict__:
             yield getattr(self, item)
+
+
+class UnitAlreadyRegistered(ValueError):
+    """Raised when a unit has previously been registered."""
+
+    def __init__(self, name: str):
+        super().__init__(f"Unable to override `{name}` it has already been registered.")


### PR DESCRIPTION
I did another round of documentation cleanups:

- In each module the documentation comes in the order classes, functions, exceptions. I've used autoclass, auto function and autoexception to force the order.
- I've reworded the documentation for exception classes to say "Raised when ...."
- I've made a number of free functions in the `units` module protected.  They are all used for the internal implementation and don't need to be part of the generated html documentation.
- I put the exceptions and free functions after the main class in each module so you see the class first when you load up the file.
- exclude-members:  in the rst configs referred to dunder methods that are not documented by default and to no longer existing exception members.