### PR TITLE
refactor: Disallow value as string

### DIFF
--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -78,6 +78,8 @@ class Quantity:
             raise InsufficientArguments()
 
         if not isinstance(value, (float, int)):
+            if isinstance(value, str):
+                raise ValueError("value should be either float, int or [float, int].")
             if _array:
                 if isinstance(value, _array.ndarray):
                     self._value = value

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -79,7 +79,7 @@ class Quantity:
 
         if not isinstance(value, (float, int)):
             if isinstance(value, str):
-                raise ValueError("value should be either float, int or [float, int].")
+                raise TypeError("value should be either float, int or [float, int].")
             if _array:
                 if isinstance(value, _array.ndarray):
                     self._value = value

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -589,3 +589,8 @@ def test_error_messages():
 
     e4 = RequiresUniqueDimensions(Unit("mm"), Unit("m"))
     assert str(e4) == "For 'mm' to be added 'm' must be removed."
+
+
+def test_value_as_string():
+    with pytest.raises(ValueError):
+        q = Quantity("string", "m")

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -592,5 +592,5 @@ def test_error_messages():
 
 
 def test_value_as_string():
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         q = Quantity("string", "m")


### PR DESCRIPTION

`q = ansunits.Quantity("string", "m")` was allowed.

![image](https://github.com/ansys/pyansys-units/assets/106588300/f6e32292-43cb-4683-9df1-12c28e6529b6)
