### PR TITLE
fix: quantity comparisons

### DIFF
--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -405,7 +405,7 @@ class Quantity:
 
     def __eq__(self, __value):
         self.validate_matching_dimensions(__value)
-        if all((isinstance(x.value, float) for x in (self, __value))):
+        if isinstance(self.value, float):
             return self._compute_single_value_comparison(__value, op=operator.eq)
         # no type-checking here since array_equal happily processes anything
         return _array and _array.array_equal(get_si_value(self), get_si_value(__value))

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -420,15 +420,18 @@ class Quantity:
 
 def get_si_value(quantity: Quantity) -> float:
     """Returns a quantity's value in SI units."""
+
+    def _convert(value, offset, factor):
+        return float((value + offset) * factor)
+
     if isinstance(quantity.value, float):
-        return float(
-            (quantity.value + quantity.units.si_offset)
-            * quantity.units.si_scaling_factor
+        return _convert(
+            quantity.value, quantity.units.si_offset, quantity.units.si_scaling_factor
         )
     if _array and isinstance(quantity.value, _array.ndarray):
         offset = quantity.units.si_offset
         factor = quantity.units.si_scaling_factor
-        return _array.array([((x + offset) * factor) for x in quantity.value])
+        return _array.array([_convert(x, offset, factor) for x in quantity.value])
 
 
 class ExcessiveParameters(ValueError):

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -405,7 +405,17 @@ class Quantity:
 
     def __eq__(self, __value):
         self.validate_matching_dimensions(__value)
-        if isinstance(self.value, float):
+        if all(
+            (
+                isinstance(self.value, float),
+                any(
+                    (
+                        isinstance(x, float)
+                        for x in (__value, getattr(__value, "value", None))
+                    )
+                ),
+            )
+        ):
             return self._compute_single_value_comparison(__value, op=operator.eq)
         # no type-checking here since array_equal happily processes anything
         return _array and _array.array_equal(get_si_value(self), get_si_value(__value))

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -381,15 +381,11 @@ class Quantity:
 
     def _compute_single_value_comparison(self, __value, op: operator):
         """Compares quantity values."""
-        try:
-            return (
-                op(get_si_value(self), __value)
-                if self.is_dimensionless
-                else op(get_si_value(self), get_si_value(__value))
-            )
-        # ValueError raised for e.g., incompatible arrays
-        except ValueError:
-            return False
+        return (
+            op(get_si_value(self), __value)
+            if self.is_dimensionless
+            else op(get_si_value(self), get_si_value(__value))
+        )
 
     def __gt__(self, __value):
         self.validate_matching_dimensions(__value)

--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -150,13 +150,6 @@ class Quantity:
         """Value in contained units."""
         return self._value
 
-    # Given the complex constraints applied in the constructor, it is
-    # unclear why we are simply allowing the value to be overwritten here.
-    # See what tests are affected by removing this.
-    @value.setter
-    def value(self, new_value):
-        self._value = new_value
-
     @property
     def units(self) -> Unit:
         """The quantity's units."""

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -131,6 +131,8 @@ def test_array_compare():
         Quantity([7, 8, 9], "kg") == Quantity([7, 8, 9], "m")
     assert Quantity([7, 8, 9], "kg") != Quantity([7, 8, 9], "g")
     assert Quantity([7, 8, 9], "") == Quantity([7, 8, 9], "")
+    assert Quantity(1, "kg") != Quantity([1, 2, 3], "kg")
+    assert Quantity([1, 2, 3], "kg") != Quantity(1, "kg")
 
 
 def test_array_to_si_value():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -130,12 +130,19 @@ def test_array_compare():
     with pytest.raises(IncompatibleDimensions):
         Quantity([7, 8, 9], "kg") == Quantity([7, 8, 9], "m")
     assert Quantity([7, 8, 9], "kg") != Quantity([7, 8, 9], "g")
+    assert Quantity([7, 8, 9], "") == Quantity([7, 8, 9], "")
 
 
 def test_array_to_si_value():
     si_value = get_si_value(Quantity([1, 2], "in"))
     assert si_value[0] == get_si_value(Quantity(1, "in"))
     assert si_value[1] == get_si_value(Quantity(2, "in"))
+
+
+def test_array_to():
+    to = Quantity([1, 2], "in").to("m")
+    assert to.value[0] == get_si_value(Quantity(1, "in"))
+    assert to.value[1] == get_si_value(Quantity(2, "in"))
 
 
 def test_to():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -68,11 +68,15 @@ def test_properties():
     assert v.dimensions == Dimensions({dims.LENGTH: 1.0})
 
 
-def test_value_setter():
+def test_quantity_is_immutable():
     v = Quantity(1, "m")
-    v.value = 20
-    assert v.value == 20
-    assert v.units == Unit("m")
+    with pytest.raises(AttributeError):
+        v.value = 20
+    with pytest.raises(AttributeError):
+        v.units = "kg"
+    with pytest.raises(AttributeError):
+        v.dimensions = Dimensions({})
+    assert v == Quantity(1, "m")
 
 
 def test_conversion():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -122,6 +122,22 @@ def test_array():
             e2 = Quantity([7, 8, 9], "kg")
 
 
+def test_array_compare():
+    assert Quantity([7, 8, 9], "kg") == Quantity([7, 8, 9], "kg")
+    assert Quantity([7, 8, 9], "kg") != Quantity([1, 2, 3], "kg")
+    with pytest.raises(IncompatibleDimensions):
+        Quantity([7, 8, 9], "kg") != Quantity([7, 8, 9], "m")
+    with pytest.raises(IncompatibleDimensions):
+        Quantity([7, 8, 9], "kg") == Quantity([7, 8, 9], "m")
+    assert Quantity([7, 8, 9], "kg") != Quantity([7, 8, 9], "g")
+
+
+def test_array_to_si_value():
+    si_value = get_si_value(Quantity([1, 2], "in"))
+    assert si_value[0] == get_si_value(Quantity(1, "in"))
+    assert si_value[1] == get_si_value(Quantity(2, "in"))
+
+
 def test_to():
     v = Quantity(1.0, "m")
     to = v.to("ft")

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -122,7 +122,17 @@ def test_array():
             e2 = Quantity([7, 8, 9], "kg")
 
 
+def _supporting_numpy():
+    try:
+        import numpy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def test_array_compare():
+    if not _supporting_numpy():
+        return
     assert Quantity([7, 8, 9], "kg") == Quantity([7, 8, 9], "kg")
     assert Quantity([7, 8, 9], "kg") != Quantity([1, 2, 3], "kg")
     with pytest.raises(IncompatibleDimensions):
@@ -136,12 +146,16 @@ def test_array_compare():
 
 
 def test_array_to_si_value():
+    if not _supporting_numpy():
+        return
     si_value = get_si_value(Quantity([1, 2], "in"))
     assert si_value[0] == get_si_value(Quantity(1, "in"))
     assert si_value[1] == get_si_value(Quantity(2, "in"))
 
 
 def test_array_to():
+    if not _supporting_numpy():
+        return
     to = Quantity([1, 2], "in").to("m")
     assert to.value[0] == get_si_value(Quantity(1, "in"))
     assert to.value[1] == get_si_value(Quantity(2, "in"))


### PR DESCRIPTION
- **Fix some issues related to array support**.
- These arose when integrating units into PyFluent.
- `get_si_value()` supports arrays.
- Equality/inequality comparisons of arrays are supported (single boolean returned). No other comparisons are added as they are undefined. 
- Added some other code comment where noticing something strange.

- Merged #244 here:
- make quantity immutable
- test all aspects of immutability
- remove setter