### PR TITLE
tuple support in quantity

### DIFF
--- a/src/ansys/units/quantity.py
+++ b/src/ansys/units/quantity.py
@@ -416,6 +416,9 @@ class Quantity:
     def __ne__(self, __value):
         return not self.__eq__(__value)
 
+    def __iter__(self):
+        return (x for x in (self.value, self.units.name))
+
 
 def get_si_value(quantity: Quantity) -> float:
     """Returns a quantity's value in SI units."""

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -637,3 +637,18 @@ def test_error_messages():
 def test_value_as_string():
     with pytest.raises(TypeError):
         q = Quantity("string", "m")
+
+
+def test_to_tuple():
+    assert tuple(Quantity(1.0)) == (1, "")
+    assert tuple(Quantity(1.0, "")) == (1, "")
+    assert tuple(Quantity(1.0, "m")) == (1, "m")
+    assert tuple(Quantity(1.0, "m")) == (1, "m")
+    arr = Quantity([1])
+    arr_in_tup = tuple(arr)
+    assert arr_in_tup[0] == Quantity([1])
+    assert arr_in_tup[1] == ""
+    arr = Quantity([1], "m")
+    arr_in_tup = tuple(arr)
+    assert arr_in_tup[0] == Quantity([1])
+    assert arr_in_tup[1] == "m"


### PR DESCRIPTION
- **support implict conversion from `Quantity` to `tuple`
- I think that is a reasoable addition to the interface. We can easily swap tuple to `Quantity`. Given the PyFluent usage, I think it's useful to be able to go the other way. 
- See the tests for more details.