### PR TITLE
fix: Dimensions less division units

### DIFF
--- a/src/ansys/units/unit.py
+++ b/src/ansys/units/unit.py
@@ -77,8 +77,6 @@ class Unit:
             self._dimensions = Dimensions(_dimensions)
             if dimensions and self._dimensions != dimensions:
                 raise InconsistentDimensions()
-            if not self._dimensions:
-                self._name = ""
 
         elif dimensions:
             self._dimensions = dimensions

--- a/src/ansys/units/unit.py
+++ b/src/ansys/units/unit.py
@@ -72,11 +72,13 @@ class Unit:
             units = _table_to_units(table=table)
 
         if units:
-            self._name = units
+            self._name = _condense(units)
             _dimensions = _units_to_dim(units=units)
             self._dimensions = Dimensions(_dimensions)
             if dimensions and self._dimensions != dimensions:
                 raise InconsistentDimensions()
+            if not self._dimensions:
+                self._name = ""
 
         elif dimensions:
             self._dimensions = dimensions

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -375,6 +375,14 @@ def test_rdiv():
     assert q2.units == Unit("m^-1 s")
 
 
+def test_dimensionless_div():
+    length_1 = Quantity(50, "mm")
+    length_2 = Quantity(40, "inch")
+    result = length_1 / length_2
+    result.value == 1.25
+    result.units == "mm inch^-1"
+
+
 def test_quantity_divided_by_unit():
     dims = BaseDimensions
     ur = UnitRegistry()

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -56,7 +56,7 @@ def test_unitless():
     assert u_1.name == ""
     assert u_1.dimensions == Dimensions()
 
-    assert u_2.name == ""
+    assert u_2.name == "m^0"
     assert u_2.dimensions == Dimensions()
 
 

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -56,7 +56,7 @@ def test_unitless():
     assert u_1.name == ""
     assert u_1.dimensions == Dimensions()
 
-    assert u_2.name == "m^0"
+    assert u_2.name == ""
     assert u_2.dimensions == Dimensions()
 
 


### PR DESCRIPTION
 

```
>>> from ansys.units import Quantity, Unit
>>> length_1 = Quantity(50, "mm")
>>> length_2 = Quantity(40, "inch")
>>> length_1 / length_2
Quantity (1.25, "mm inch^-1")

>>> t = Quantity(1, "mm^0")
>>> t
Quantity (1.0, "")

>>> j = Quantity(1.0, "m^0 kg")
>>> j
Quantity (1.0, "kg")
>>>
```
