### PR TITLE
fix: Update temperature conversion factor

### DIFF
--- a/src/ansys/units/cfg.yaml
+++ b/src/ansys/units/cfg.yaml
@@ -168,11 +168,11 @@ base_units:
     si_offset: 273.15
   F:
     type: TEMPERATURE
-    si_scaling_factor: 0.55555555555
+    si_scaling_factor: 0.5555555555555555
     si_offset: 459.67
   R:
     type: TEMPERATURE
-    si_scaling_factor: 0.55555555555
+    si_scaling_factor: 0.5555555555555555
     si_offset: 0
   delta_K:
     type: TEMPERATURE_DIFFERENCE
@@ -184,11 +184,11 @@ base_units:
     si_offset: 0
   delta_F:
     type: TEMPERATURE_DIFFERENCE
-    si_scaling_factor: 0.55555555555
+    si_scaling_factor: 0.5555555555555555
     si_offset: 0
   delta_R:
     type: TEMPERATURE_DIFFERENCE
-    si_scaling_factor: 0.55555555555
+    si_scaling_factor: 0.5555555555555555
     si_offset: 0
 
 # Derived Units

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -281,7 +281,7 @@ def test_temp_subtraction():
 
     t5 = Quantity(10.0, "delta_F")
     t6 = t5 - t4
-    assert t6 == Quantity(-25.60000000495262, "F")
+    assert t6 == Quantity(-25.600000000000023, "F")
 
 
 def test_pow():

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -668,3 +668,11 @@ def test_error_messages():
 def test_value_as_string():
     with pytest.raises(TypeError):
         q = Quantity("string", "m")
+
+
+def test_C_to_F():
+    ureg = UnitRegistry()
+    five_c = Quantity(value=5.0, units=ureg.C)
+    converted = five_c.to(ureg.F)
+    assert converted.value == 41.0
+    assert converted.units._name == "F"


### PR DESCRIPTION
closes https://github.com/ansys/pyansys-units/issues/285

1. Update temperature conversion factors.
2. Add test for updated conversion factors.
3. Update test of `delta_F`

```
>>> from ansys.units import Quantity, UnitRegistry
>>> ureg = UnitRegistry()
>>> five_c = Quantity(value=5.0, units=ureg.C)
>>> five_c.to(ureg.F)
Quantity (41.0, "F")
>>>
```
