### PR TITLE
fix: Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  MAIN_PYTHON_VERSION: '3.9'
+  MAIN_PYTHON_VERSION: '3.10'
   DOCUMENTATION_CNAME: 'units.docs.pyansys.com'
   LIBRARY_NAME: 'ansys-units'
   LIBRARY_NAMESPACE: 'ansys.units'
@@ -61,7 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - uses: ansys/actions/build-wheelhouse@v5.1
         with:
@@ -76,7 +76,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
       fail-fast: false
     steps:
       - uses: ansys/actions/tests-pytest@v5.1

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ To reach the project support team, email `pyansys.core@ansys.com <pyansys.core@a
 Installation
 ------------
 
-The ``ansys.units`` package supports Python 3.9 through Python 3.11 on Windows
+The ``ansys.units`` package supports Python 3.10 through Python 3.12 on Windows
 and Linux.
 
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Installation
 ============
 
-The ``ansys-units`` package supports Python 3.9 through Python 3.11 on Windows
+The ``ansys-units`` package supports Python 3.10 through Python 3.12 on Windows
 and Linux.
 
 Install the package


### PR DESCRIPTION
closes https://github.com/ansys/pyansys-units/issues/288

Drop support for Python 3.9