### PR TITLE
fix: Remove pdf2image, add in pint as it's imported to the tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ tests = [
     "pytest==8.3.4",
     "pytest-cov==6.0.0",
     "pytest-mock==3.14.0",
-    "pint==0.17",
+    "pint==0.24.4",
 ]
 lists = [
     "numpy==2.2.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 
 dependencies = [
     "importlib-metadata>=4.0",
-    "pdf2image>=1.17.0",
     "pyyaml>=6.0",
 ]
 
@@ -44,6 +43,7 @@ tests = [
     "pytest==8.3.4",
     "pytest-cov==6.0.0",
     "pytest-mock==3.14.0",
+    "pint==0.17",
 ]
 lists = [
     "numpy==2.2.2",

--- a/tests/lib_compare/test_angle_units.py
+++ b/tests/lib_compare/test_angle_units.py
@@ -150,11 +150,11 @@ def test_pint_conversion_between_Hz_and_rps_and_radians_per_second():
     )
     radians_per_second = hz.to(ur.radian / ur.s)
     assert_rightly_but_fail(
-        2.0 * math.pi * pint_value(hz) == pytest.approx(radians_per_second),
+        2.0 * math.pi * pint_value(hz) == pytest.approx(radians_per_second.magnitude),
         "2 pi factor for Hz and rad/s",
     )
     assert_wrongly(
-        pint_value(hz) == pytest.approx(radians_per_second),
+        pint_value(hz) == pytest.approx(radians_per_second.magnitude),
         "equivalence of Hz and rad/s",
     )
     # The problem is: one radian is asserted to be unity


### PR DESCRIPTION
- Not even sure why this pdf2image dependency is there. 
- pint is needed for some marked developer tests to run so added it to the test dependencies.  Running the tests locally on the command line or in VS code fails.