### PR TITLE
build: flexible dependencies for pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
 
 dependencies = [
     "importlib-metadata>=4.0",
-    "pydantic==2.11.7",
-    "pydantic_core==2.33.2",
+    "pydantic>=2.11.7",
+    "pydantic_core>=2.33.2",
     "pyyaml>=6.0",
 ]
 


### PR DESCRIPTION
This is a too restrictive requirement for the ecosystem at large- with this requirement you are forcing all libraries (when installed together) to use your version. Could we make the range more flexible?