### PR TITLE
chore: Update release and publish actions

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -134,6 +134,9 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags')
     needs: [build-library]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # required for trusted publishing
+      contents: write # required for GitHub release upload
     steps:
       - name: "Release to the private PyPI repository"
         uses: ansys/actions/release-pypi-private@v10
@@ -142,12 +145,19 @@ jobs:
           twine-username: "__token__"
           twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 
-      - name: "Release to the public PyPI repository"
-        uses: ansys/actions/release-pypi-public@v10
+      - name: "Download the library artifacts from build-library step"
+        uses: actions/download-artifact@v4.3.0
         with:
-          library-name: ${{ env.LIBRARY_NAME }}
-          twine-username: "__token__"
-          twine-token: ${{ secrets.PYPI_TOKEN }}
+          name: ${{ env.LIBRARY_NAME }}-artifacts
+          path: ${{ env.LIBRARY_NAME }}-artifacts
+
+      - name: "Upload artifacts to PyPI using trusted publisher"
+        uses: pypa/gh-action-pypi-publish@v1.12.4
+        with:
+          repository-url: "https://upload.pypi.org/legacy/"
+          print-hash: true
+          packages-dir: ${{ env.LIBRARY_NAME }}-artifacts
+          skip-existing: false
 
       - name: "Release to GitHub"
         uses: ansys/actions/release-github@v10


### PR DESCRIPTION
This pull request updates the CI/CD workflow configuration in `.github/workflows/ci_cd.yml` to improve the process for publishing Python packages to PyPI and GitHub. The main changes involve switching to PyPI's trusted publisher action and updating permissions for secure artifact uploads.

**PyPI Publishing Improvements:**

* Switched public PyPI publishing to use the official `pypa/gh-action-pypi-publish` action with trusted publisher support, replacing the previous `ansys/actions/release-pypi-public` action. This enhances security and aligns with recommended PyPI practices.
* Added a step to download build artifacts before uploading to PyPI, ensuring the correct files are published.

**Workflow Permissions and Security:**

* Updated permissions for the release job to grant `id-token: write` (required for trusted publishing) and `contents: write` (required for GitHub release uploads), supporting secure and authorized publishing.