### PR TITLE
fix: Change numpy range

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,16 +39,14 @@ doc = [
     "sphinx-toggleprompt==0.6.0",
 ]
 tests = [
-    "numpy==2.2.6; python_version >'3.10'",  # TODO: Limit to be removed once Python 3.10 support is dropped
-    "numpy==1.26.4; python_version <= '3.10'",  # TODO: Dependency to be removed once Python 3.10 support is dropped
+    "numpy>=1.24,<3",
     "pytest==8.4.2",
     "pytest-cov==7.0.0",
     "pytest-mock==3.15.1",
     "pint==0.24.4",
 ]
 additional = [
-    "numpy==2.2.6; python_version >'3.10'",  # TODO: Limit to be removed once Python 3.10 support is dropped
-    "numpy==1.26.4; python_version <= '3.10'",  # TODO: Dependency to be removed once Python 3.10 support is dropped
+    "numpy>=1.24,<3",
     "pydantic>=2.11.7",
     "pydantic_core>=2.33.2",
 ]


### PR DESCRIPTION
I have verified that after updating matplotlib version, we don't get dependency conflict now.

```
(pyfluent) PS D:\Repos\pyfluent> python --version
Python 3.10.11
(pyfluent) PS D:\Repos\pyfluent> python
Python 3.10.11 (tags/v3.10.11:7d4cc5a, Apr  5 2023, 00:38:17) [MSC v.1929 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
Ctrl click to launch VS Code Native REPL
>>> import ansys.fluent.core as pf
>>> from ansys.units.variable_descriptor import MappingConversionStrategy, VariableCatalog           
>>>
```