### PR TITLE
fix(workflows): permissions for doc-deploy-stable

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -206,6 +206,8 @@ jobs:
     if: github.event_name == 'push' && contains(github.ref, 'refs/tags') && !contains(github.ref, 'dev')
     runs-on: ubuntu-latest
     needs: [release]
+    permissions:
+      contents: write
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@v10


### PR DESCRIPTION
Fix the issues raised in https://github.com/ansys/pyansys-units/actions/runs/19473028017/job/55778695766 by allowing write access to the `GH_TOKEN` in the `doc-deploy-stable` job.