### PR TITLE
REFACTOR: Update register unit functionality

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -15,7 +15,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
+  packages: read # Needed to pull images from GitHub Container Registry
   pull-requests: read
   issues: read
 
@@ -202,7 +202,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release]
     permissions:
-      contents: write
+      contents: write # Needed to deploy documentation to the repository
     steps:
       - name: Deploy the stable documentation
         uses: ansys/actions/doc-deploy-stable@v10.2.12

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -12,7 +12,7 @@ concurrency:
 
 permissions:
   contents: read
-  packages: read
+  packages: read # Needed to pull images from GitHub Container Registry
   pull-requests: read
   issues: read
 
@@ -33,7 +33,7 @@ jobs:
     needs: [label-syncer]
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: write # Needed to add labels to pull requests
       pages: write
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [labeler]
     permissions:
-      pull-requests: write
+      pull-requests: write # Needed to comment on pull requests
     steps:
       - name: Suggest to add labels
         uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0

--- a/doc/source/api/unit_registry.rst
+++ b/doc/source/api/unit_registry.rst
@@ -10,5 +10,5 @@ Unit registry
    :undoc-members:
    :exclude-members:
 
-.. autoexception:: ansys.units.unit_registry.UnitAlreadyRegistered
+.. autoexception:: ansys.units.unit_registry.UnitNameAlreadyRegistered
    :show-inheritance:

--- a/doc/source/api/unit_registry.rst
+++ b/doc/source/api/unit_registry.rst
@@ -12,3 +12,6 @@ Unit registry
 
 .. autoexception:: ansys.units.unit_registry.UnitNameAlreadyRegistered
    :show-inheritance:
+
+.. autoexception:: ansys.units.unit_registry.AliasAlreadyRegistered
+   :show-inheritance:

--- a/doc/source/cheatsheet/cheat_sheet.qmd
+++ b/doc/source/cheatsheet/cheat_sheet.qmd
@@ -263,16 +263,32 @@ ureg.register_alias("angular_deg", "degree")
 Unit("angular_deg")  # resolves to "degree"
 ```
 
-### Registering custom units
+### Registering custom units at construction
+
+```{python}
+from ansys.units import UnitRegistry, get_si_value
+
+ur = UnitRegistry(custom_units=[
+    {"unit": "micron", "composition": "m", "factor": 1e-6},
+    {"unit": "thou", "composition": "m", "factor": 2.54e-5},
+])
+
+q = ur.Quantity(1, "micron")  # String-based lookup
+get_si_value(q)  # 1e-06
+```
+
+### Registering custom units after construction
 
 ```{python}
 from ansys.units import UnitRegistry
 
 ur = UnitRegistry()
-
-# Register 'Q' as equivalent to Joule (N m)
 ur.register_unit(unit="Q", composition="N m", factor=1)
 ur.Q == ur.J  # True
+
+# String-based lookup methods
+unit = ur.get_unit("Q")
+q = ur.Quantity(5, "Q")
 ```
 
 ### Quantity dimensions

--- a/doc/source/user_guide/register_unit.rst
+++ b/doc/source/user_guide/register_unit.rst
@@ -1,43 +1,100 @@
 Registering Custom Units
 ========================
 
-You can register new derived units at runtime using
-instance-scoped registration directly on a ``UnitRegistry`` instance.
+You can register new derived units at runtime using instance-scoped
+registration on a ``UnitRegistry`` instance.
 
-Instance-Scoped
+At Construction
 ---------------
 
-- The ``UnitRegistry.register_unit(name, composition, factor)`` method adds a new unit
-  symbol to that registry instance.
-- Duplicate registrations on the same instance (including collisions with
-  built-in units) raise ``UnitNameAlreadyRegistered``.
+Use the ``custom_units`` parameter to register units when creating a registry:
 
+.. code-block:: python
 
-Example
--------
+    from ansys.units import UnitRegistry, get_si_value
+
+    ur = UnitRegistry(
+        custom_units=[
+            {"unit": "micron", "composition": "m", "factor": 1e-6},
+            {"unit": "thou", "composition": "m", "factor": 2.54e-5},
+        ]
+    )
+
+    # Use string-based lookup with ur.Quantity()
+    q = ur.Quantity(10, "micron")
+    print(get_si_value(q))  # 1e-05
+
+After Construction
+------------------
+
+Use ``register_unit()`` to add units to an existing registry:
 
 .. code-block:: python
 
     from ansys.units import UnitRegistry
 
     ur = UnitRegistry()
-
-    # Register a symbol 'Q' equivalent to Joule (N m)
-    ur.register_unit(name="Q", composition="N m", factor=1)
+    ur.register_unit(unit="Q", composition="N m", factor=1)
     assert ur.Q == ur.J
 
-    # A new registry does not see instance registrations
-    ur2 = UnitRegistry()
-    try:
-        _ = ur2.Q
-        raise AssertionError("Expected AttributeError for ur2.Q")
-    except AttributeError:
-        pass
+String-Based Lookup
+-------------------
+
+Registered units can be accessed by name using:
+
+- ``ur.get_unit(name)`` - Returns the ``Unit`` object
+- ``ur.Quantity(value, name)`` - Creates a ``Quantity`` with the registered unit
+
+.. code-block:: python
+
+    ur = UnitRegistry(
+        custom_units=[
+            {"unit": "micron", "composition": "m", "factor": 1e-6},
+        ]
+    )
+
+    # String-based lookup
+    unit = ur.get_unit("micron")
+    q = ur.Quantity(1, "micron")
 
 .. note::
-  Dynamic registration is instance-scoped. Register units on the specific
-  ``UnitRegistry`` you want to use; new registries do not automatically
-  inherit instance-registered units.
+   The global ``Quantity()`` constructor does not see instance-registered units.
+   Use ``ur.Quantity()`` for string-based creation with custom units.
+
+Instance Isolation
+------------------
+
+Each registry maintains its own set of registered units:
+
+.. code-block:: python
+
+    ur1 = UnitRegistry(custom_units=[{"unit": "X", "composition": "m", "factor": 10}])
+    ur2 = UnitRegistry(custom_units=[{"unit": "X", "composition": "m", "factor": 100}])
+    ur3 = UnitRegistry()  # No custom units
+
+    ur1.X.si_scaling_factor  # 10
+    ur2.X.si_scaling_factor  # 100
+    ur3.X  # AttributeError - not registered
+
+Collision Detection
+-------------------
+
+The collision check is **name-only**:
+
+- Duplicate names raise ``UnitNameAlreadyRegistered``
+- Built-in unit names (``m``, ``kg``, ``J``, etc.) cannot be overridden
+- Equivalent definitions with different names are allowed
+
+.. code-block:: python
+
+    ur = UnitRegistry()
+
+    # These are allowed (different names, same definition)
+    ur.register_unit(unit="energy1", composition="N m", factor=1)
+    ur.register_unit(unit="energy2", composition="N m", factor=1)
+
+    # This raises UnitNameAlreadyRegistered
+    ur.register_unit(unit="m", composition="ft", factor=1)  # Error!
 
 Notes
 -----

--- a/doc/source/user_guide/register_unit.rst
+++ b/doc/source/user_guide/register_unit.rst
@@ -10,7 +10,7 @@ Instance-Scoped
 - The ``UnitRegistry.register_unit(name, composition, factor)`` method adds a new unit
   symbol to that registry instance.
 - Duplicate registrations on the same instance (including collisions with
-  built-in units) raise ``UnitAlreadyRegistered``.
+  built-in units) raise ``UnitNameAlreadyRegistered``.
 
 
 Example

--- a/src/ansys/units/unit_registry.py
+++ b/src/ansys/units/unit_registry.py
@@ -180,7 +180,7 @@ class UnitRegistry:
 
     def Quantity(
         self,
-        value: "int | float | Sequence",
+        value: "int | float | Sequence[float]",
         units: "str | Unit",
     ) -> "Quantity":
         """

--- a/src/ansys/units/unit_registry.py
+++ b/src/ansys/units/unit_registry.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 """Provides the ``UnitRegistry`` class and instance-scoped unit registration."""
 
-from collections.abc import Generator, Mapping
+from collections.abc import Generator, Mapping, Sequence
 import math
 import os
 from typing import TYPE_CHECKING, Any
@@ -38,6 +38,9 @@ from ansys.units._constants import _aliases as _CONST_ALIASES
 from ansys.units._constants import _base_units as _CONST_BASE_UNITS
 from ansys.units._constants import _derived_units as _CONST_DERIVED_UNITS
 from ansys.units.unit import Unit
+
+if TYPE_CHECKING:
+    from ansys.units.quantity import Quantity  # noqa: F401
 
 
 class UnitRegistry:
@@ -88,7 +91,7 @@ class UnitRegistry:
         for unit_name in unitdict:
             # Prevent overriding attributes already present on this instance
             if hasattr(self, unit_name):
-                raise UnitAlreadyRegistered(unit_name)
+                raise UnitNameAlreadyRegistered(unit_name)
 
             cfg = unitdict[unit_name]
             if unit_name in _CONST_BASE_UNITS or unit_name in _CONST_DERIVED_UNITS:
@@ -118,11 +121,77 @@ class UnitRegistry:
 
     def __setattr__(self, name: str, unit: Any) -> None:
         if hasattr(self, name):
-            raise UnitAlreadyRegistered(name)
+            raise UnitNameAlreadyRegistered(name)
         self.__dict__[name] = unit
 
     def __iter__(self) -> Generator[str]:
         yield from self.__dict__
+
+    def get_unit(self, name: str) -> Unit:
+        """
+        Look up a unit by name from this registry.
+
+        Checks instance-registered units first, then falls back to built-in
+        units. This allows string-based lookup of custom registered units.
+
+        Parameters
+        ----------
+        name : str
+            The unit name to look up.
+
+        Returns
+        -------
+        Unit
+            The unit object.
+
+        Raises
+        ------
+        AttributeError
+            If the unit is not found in this registry or built-ins.
+        """
+        if name in self.__dict__:
+            return self.__dict__[name]
+        # Fall back to creating from global config
+        if name in _CONST_BASE_UNITS or name in _CONST_DERIVED_UNITS:
+            return Unit(name)
+        raise AttributeError(f"Unit `{name}` not found in this registry.")
+
+    def Quantity(
+        self,
+        value: "int | float | Sequence",
+        units: "str | Unit",
+    ) -> "Quantity":
+        """
+        Create a Quantity using this registry's units.
+
+        This method allows creating quantities with instance-registered units
+        using string names.
+
+        Parameters
+        ----------
+        value : int, float, or sequence
+            The numeric value.
+        units : str or Unit
+            The unit name (looked up in this registry) or a Unit object.
+
+        Returns
+        -------
+        Quantity
+            The created quantity.
+
+        Examples
+        --------
+        >>> ur = UnitRegistry()
+        >>> ur.register_unit(unit="micron", composition="m", factor=1e-6)
+        >>> q = ur.Quantity(1, "micron")
+        >>> print(q)
+        1.0 micron
+        """
+        from ansys.units.quantity import Quantity as _Quantity
+
+        if isinstance(units, str):
+            units = self.get_unit(units)
+        return _Quantity(value, units)
 
     def register_unit(
         self,
@@ -135,14 +204,16 @@ class UnitRegistry:
         Register a new derived unit on this ``UnitRegistry`` instance.
 
         This is instance-scoped: it affects only this registry and does not
-        mutate global state or other registries.
+        mutate global state or other registries. The registered unit can be
+        accessed as an attribute (e.g., ``ur.micron``) or via
+        :meth:`get_unit` for string-based lookup.
 
         Parameters
         ----------
         unit: str
-            The symbol/name of the new unit (e.g., "Q"). Preferred keyword.
+            The symbol/name of the new unit (e.g., "micron").
         composition: str
-            A valid unit composition using existing configured units (e.g., "N m").
+            A valid unit composition using existing configured units (e.g., "m").
         factor: float
             Scale factor that relates the composition to this unit.
 
@@ -153,10 +224,24 @@ class UnitRegistry:
 
         Raises
         ------
-        UnitAlreadyRegistered
-            If a unit with the same name already exists on this instance or is built-in.
+        UnitNameAlreadyRegistered
+            If a unit with the same name already exists on this instance or
+            as a built-in. This is a name-only check and does not detect
+            equivalent definitions with different names.
         ValueError
             If ``unit`` is empty or ``factor`` is not finite.
+
+        Notes
+        -----
+        The name collision check is superficial (name-only). Two units with
+        different names but equivalent definitions (same composition and factor)
+        can both be registered without error.
+
+        Examples
+        --------
+        >>> ur = UnitRegistry()
+        >>> ur.register_unit(unit="micron", composition="m", factor=1e-6)
+        >>> q = ur.Quantity(1, "micron")  # Use registry's Quantity method
         """
         unit = unit.strip()
         if not unit:
@@ -165,13 +250,13 @@ class UnitRegistry:
         if not math.isfinite(f):
             raise ValueError("`factor` must be a finite number.")
 
-        # Prevent overriding built-ins or existing attributes on this instance
+        # Name-only collision check against built-ins and this instance
         if (
             unit in _CONST_BASE_UNITS
             or unit in _CONST_DERIVED_UNITS
             or hasattr(self, unit)
         ):
-            raise UnitAlreadyRegistered(unit)
+            raise UnitNameAlreadyRegistered(unit)
 
         composed = Unit(units=str(composition))
         obj = Unit(copy_from=composed)
@@ -245,8 +330,15 @@ class AliasAlreadyRegistered(ValueError):
         )
 
 
-class UnitAlreadyRegistered(ValueError):
-    """Raised when a unit has previously been registered."""
+class UnitNameAlreadyRegistered(ValueError):
+    """
+    Raised when a unit name conflicts with an existing name.
+
+    This is a name-only check. Units with different names but equivalent definitions
+    (same composition and factor) are not detected.
+    """
 
     def __init__(self, name: str):
-        super().__init__(f"Unable to override `{name}` it has already been registered.")
+        super().__init__(
+            f"Unable to register `{name}`: a unit with this name already exists."
+        )

--- a/src/ansys/units/unit_registry.py
+++ b/src/ansys/units/unit_registry.py
@@ -154,12 +154,14 @@ class UnitRegistry:
         Look up a unit by name from this registry.
 
         Checks instance-registered units first, then falls back to built-in
-        units. This allows string-based lookup of custom registered units.
+        units and compound unit strings. This allows string-based lookup of
+        custom registered units as well as standard unit expressions.
 
         Parameters
         ----------
         name : str
-            The unit name to look up.
+            The unit name or compound unit string to look up (e.g., "micron",
+            "m", "kg mol^-1").
 
         Returns
         -------
@@ -169,14 +171,16 @@ class UnitRegistry:
         Raises
         ------
         AttributeError
-            If the unit is not found in this registry or built-ins.
+            If the unit is not found in this registry or cannot be parsed.
         """
+        # First check instance-registered units
         if name in self.__dict__:
             return self.__dict__[name]
-        # Fall back to creating from global config
-        if name in _CONST_BASE_UNITS or name in _CONST_DERIVED_UNITS:
+        # Fall back to creating a Unit (handles built-ins and compound strings)
+        try:
             return Unit(name)
-        raise AttributeError(f"Unit `{name}` not found in this registry.")
+        except Exception as e:
+            raise AttributeError(f"Unit `{name}` not found in this registry.") from e
 
     def Quantity(
         self,

--- a/src/ansys/units/unit_registry.py
+++ b/src/ansys/units/unit_registry.py
@@ -57,7 +57,11 @@ class UnitRegistry:
         defaults to the provided file, ``cfg.yaml``. Custom configuration files
         must match the format of the default configuration file.
     other: dict, optional
-        Dictionary for additional units.
+        Dictionary for additional units (uses config file format).
+    custom_units : list of dict, optional
+        List of custom units to register during construction. Each dict must
+        have keys ``"unit"``, ``"composition"``, and ``"factor"`` matching
+        the :meth:`register_unit` signature.
 
     Examples
     --------
@@ -66,6 +70,14 @@ class UnitRegistry:
     >>> assert ureg.kg == Unit(units="kg")
     >>> fps = Unit("ft s^-1")
     >>> ureg.foot_per_sec = fps
+
+    Register custom units at construction:
+
+    >>> ur = UnitRegistry(custom_units=[
+    ...     {"unit": "micron", "composition": "m", "factor": 1e-6},
+    ...     {"unit": "inch", "composition": "m", "factor": 0.0254},
+    ... ])
+    >>> q = ur.Quantity(10, "micron")
     """
 
     def __init__(
@@ -74,6 +86,7 @@ class UnitRegistry:
         other: Mapping[
             str, Mapping[str, Any]
         ] = {},  # pyright: ignore[reportCallInDefaultInitializer]
+        custom_units: Sequence[Mapping[str, Any]] | None = None,
     ):
         unitdict = dict(other)
 
@@ -107,6 +120,15 @@ class UnitRegistry:
                     object.__setattr__(self, unit_name, obj)
                 else:
                     object.__setattr__(self, unit_name, Unit(unit_name, cfg))
+
+        # Register custom units using the same logic as register_unit
+        if custom_units:
+            for cu in custom_units:
+                self.register_unit(
+                    unit=cu["unit"],
+                    composition=cu["composition"],
+                    factor=cu["factor"],
+                )
 
     def __str__(self):
         returned_string = ""

--- a/tests/test_register_unit.py
+++ b/tests/test_register_unit.py
@@ -150,6 +150,25 @@ def test_get_unit_builtin():
     assert unit.name == "J"
 
 
+def test_get_unit_compound_string():
+    """Test get_unit handles compound unit strings like 'kg mol^-1'."""
+    ur = UnitRegistry()
+
+    # Compound unit strings should work
+    unit = ur.get_unit("kg mol^-1")
+    assert unit.name == "kg mol^-1"
+
+    unit = ur.get_unit("m s^-2")
+    assert unit.name == "m s^-2"
+
+    # Should work consistently with Quantity
+    from ansys.units import Quantity
+
+    q1 = Quantity(1, ur.get_unit("kg mol^-1"))
+    q2 = Quantity(1, "kg mol^-1")
+    assert q1.units.name == q2.units.name
+
+
 def test_get_unit_not_found():
     """Test get_unit raises AttributeError for unknown units."""
     ur = UnitRegistry()
@@ -286,23 +305,26 @@ def test_register_unit_does_not_detect_equivalent_offset():
     assert ur.alsometer.si_scaling_factor == pytest.approx(ur.m.si_scaling_factor)
 
 
-def test_get_unit_does_not_resolve_global_aliases():
+def test_get_unit_resolves_global_aliases():
     """
-    Test that get_unit doesn't resolve global aliases for non-registered units.
+    Test that get_unit resolves global aliases via Unit().
 
-    get_unit checks instance-registered units, then falls back to built-in base/derived
-    units, but does NOT resolve aliases.
+    get_unit checks instance-registered units first, then falls back to Unit(name) which
+    handles aliases, compound strings, and built-ins.
     """
     ur = UnitRegistry()
 
-    # "deg" is a global alias for "degree", but get_unit won't find it
-    # because it only checks instance-registered and built-in (base/derived)
-    with pytest.raises(AttributeError, match="not found"):
-        ur.get_unit("deg")
+    # "deg" is a global alias for "degree" - get_unit resolves it
+    unit = ur.get_unit("deg")
+    assert unit.name == "degree"  # Resolved via alias
 
-    # "degree" (the canonical name) is a built-in derived unit
+    # "degree" (the canonical name) also works
     unit = ur.get_unit("degree")
     assert unit.name == "degree"
+
+    # Instance-registered units take precedence over aliases
+    ur.register_unit(unit="myunit", composition="m", factor=1)
+    assert ur.get_unit("myunit").name == "myunit"
 
 
 def test_register_unit_name_check_is_case_sensitive():

--- a/tests/test_register_unit.py
+++ b/tests/test_register_unit.py
@@ -346,3 +346,78 @@ def test_equivalent_compositions_same_dimensions():
     assert ur.energy_nm.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
     assert ur.energy_ws.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
     assert ur.energy_kgm2s2.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
+
+
+# =============================================================================
+# Tests for custom_units parameter in UnitRegistry constructor
+# =============================================================================
+
+
+def test_custom_units_at_construction():
+    """Test registering custom units via constructor parameter."""
+    ur = UnitRegistry(
+        custom_units=[
+            {"unit": "micron", "composition": "m", "factor": 1e-6},
+            {"unit": "thou", "composition": "m", "factor": 2.54e-5},
+        ]
+    )
+
+    # Custom units should be accessible
+    assert ur.micron.name == "micron"
+    assert ur.micron.si_scaling_factor == pytest.approx(1e-6)
+
+    assert ur.thou.name == "thou"
+    assert ur.thou.si_scaling_factor == pytest.approx(2.54e-5)
+
+    # Should work with ur.Quantity
+    q = ur.Quantity(1, "micron")
+    from ansys.units import get_si_value
+
+    assert get_si_value(q) == pytest.approx(1e-6)
+
+
+def test_custom_units_empty_list():
+    """Test that empty custom_units list doesn't cause issues."""
+    ur = UnitRegistry(custom_units=[])
+    assert ur.m.name == "m"  # Built-ins still work
+
+
+def test_custom_units_none():
+    """Test that custom_units=None (default) works."""
+    ur = UnitRegistry(custom_units=None)
+    assert ur.m.name == "m"
+
+
+def test_custom_units_collision_with_builtin():
+    """Test that custom_units cannot override built-in units."""
+    with pytest.raises(UnitNameAlreadyRegistered):
+        UnitRegistry(
+            custom_units=[
+                {"unit": "m", "composition": "ft", "factor": 1},
+            ]
+        )
+
+
+def test_custom_units_collision_within_list():
+    """Test that duplicate names within custom_units are rejected."""
+    with pytest.raises(UnitNameAlreadyRegistered):
+        UnitRegistry(
+            custom_units=[
+                {"unit": "X", "composition": "m", "factor": 1},
+                {"unit": "X", "composition": "m", "factor": 2},
+            ]
+        )
+
+
+def test_custom_units_instance_isolation():
+    """Test that custom_units are instance-scoped."""
+    ur1 = UnitRegistry(custom_units=[{"unit": "X", "composition": "m", "factor": 10}])
+    ur2 = UnitRegistry(custom_units=[{"unit": "X", "composition": "m", "factor": 100}])
+
+    assert ur1.X.si_scaling_factor == pytest.approx(10)
+    assert ur2.X.si_scaling_factor == pytest.approx(100)
+
+    # A third registry without X
+    ur3 = UnitRegistry()
+    with pytest.raises(AttributeError):
+        _ = ur3.X

--- a/tests/test_register_unit.py
+++ b/tests/test_register_unit.py
@@ -23,7 +23,7 @@
 import pytest
 
 from ansys.units import UnitRegistry
-from ansys.units.unit_registry import UnitAlreadyRegistered
+from ansys.units.unit_registry import UnitNameAlreadyRegistered
 
 
 def test_register_unit():
@@ -39,7 +39,7 @@ def test_instance_register_unit():
     ur = UnitRegistry()
 
     # Cannot override built-ins
-    with pytest.raises(UnitAlreadyRegistered):
+    with pytest.raises(UnitNameAlreadyRegistered):
         ur.register_unit(unit="J", composition="N m", factor=1)
 
     # Register alias 'Q' equal to Joule using one composition
@@ -47,7 +47,7 @@ def test_instance_register_unit():
     assert ur.Q == ur.J
 
     # Same instance cannot re-register same name
-    with pytest.raises(UnitAlreadyRegistered):
+    with pytest.raises(UnitNameAlreadyRegistered):
         ur.register_unit(unit="Q", composition="N m", factor=1)
 
     # New registry does not see instance registration
@@ -94,9 +94,255 @@ def test_duplicate_registration_same_registry():
     assert ur.B == ur.J
 
     # Re-register same name with same composition should fail
-    with pytest.raises(UnitAlreadyRegistered):
+    with pytest.raises(UnitNameAlreadyRegistered):
         ur.register_unit(unit="B", composition="N m", factor=1)
 
     # Re-register same name with different (but equivalent) composition should also fail
-    with pytest.raises(UnitAlreadyRegistered):
+    with pytest.raises(UnitNameAlreadyRegistered):
         ur.register_unit(unit="B", composition="W s", factor=1)
+
+
+def test_name_only_collision_check():
+    """
+    Test that collision detection is name-only.
+
+    Two units with different names but equivalent definitions (same composition and
+    factor) should both be allowed, demonstrating that the check is superficial (name-
+    based) rather than semantic (equivalence-based).
+    """
+    ur = UnitRegistry()
+
+    # Register two different names for equivalent definitions
+    ur.register_unit(unit="energy1", composition="N m", factor=1)
+    ur.register_unit(
+        unit="energy2", composition="N m", factor=1
+    )  # Same definition, different name
+
+    # Both should exist
+    assert ur.energy1.si_scaling_factor == pytest.approx(ur.energy2.si_scaling_factor)
+    assert ur.energy1.dimensions == ur.energy2.dimensions
+
+    # Same definition via different but equivalent composition
+    ur.register_unit(unit="energy3", composition="W s", factor=1)
+    assert ur.energy3.si_scaling_factor == pytest.approx(ur.energy1.si_scaling_factor)
+
+
+def test_get_unit_instance_registered():
+    """Test get_unit retrieves instance-registered units by name."""
+    ur = UnitRegistry()
+    ur.register_unit(unit="micron", composition="m", factor=1e-6)
+
+    # String-based lookup should work
+    unit = ur.get_unit("micron")
+    assert unit.name == "micron"
+    assert unit.si_scaling_factor == pytest.approx(1e-6)
+
+
+def test_get_unit_builtin():
+    """Test get_unit falls back to built-in units."""
+    ur = UnitRegistry()
+
+    # Built-in unit should be accessible
+    unit = ur.get_unit("m")
+    assert unit.name == "m"
+
+    unit = ur.get_unit("J")
+    assert unit.name == "J"
+
+
+def test_get_unit_not_found():
+    """Test get_unit raises AttributeError for unknown units."""
+    ur = UnitRegistry()
+
+    with pytest.raises(AttributeError, match="not found"):
+        ur.get_unit("nonexistent_unit")
+
+
+def test_registry_quantity_with_registered_unit():
+    """Test ur.Quantity() allows string-based creation with registered units."""
+    ur = UnitRegistry()
+    ur.register_unit(unit="micron", composition="m", factor=1e-6)
+
+    # Create quantity using string name
+    q = ur.Quantity(1, "micron")
+    assert q.value == 1.0
+    assert q.units.name == "micron"
+
+    # SI value should be 1e-6
+    from ansys.units import get_si_value
+
+    assert get_si_value(q) == pytest.approx(1e-6)
+
+
+def test_registry_quantity_with_builtin():
+    """Test ur.Quantity() works with built-in units."""
+    ur = UnitRegistry()
+
+    q = ur.Quantity(5, "m")
+    assert q.value == 5.0
+    assert q.units.name == "m"
+
+
+def test_registry_quantity_with_unit_object():
+    """Test ur.Quantity() accepts Unit objects directly."""
+    ur = UnitRegistry()
+    ur.register_unit(unit="micron", composition="m", factor=1e-6)
+
+    q = ur.Quantity(2, ur.micron)
+    assert q.value == 2.0
+    assert q.units.name == "micron"
+
+
+def test_registry_quantity_instance_isolation():
+    """Test that ur.Quantity uses that registry's units, not global."""
+    ur1 = UnitRegistry()
+    ur2 = UnitRegistry()
+
+    ur1.register_unit(unit="X", composition="m", factor=10)
+    ur2.register_unit(unit="X", composition="m", factor=100)
+
+    q1 = ur1.Quantity(1, "X")
+    q2 = ur2.Quantity(1, "X")
+
+    from ansys.units import get_si_value
+
+    assert get_si_value(q1) == pytest.approx(10)
+    assert get_si_value(q2) == pytest.approx(100)
+
+
+# =============================================================================
+# Edge cases: Aliasing and indirect equivalence
+# =============================================================================
+
+
+def test_register_unit_does_not_check_aliases():
+    """
+    Test that register_unit collision check does NOT include global aliases.
+
+    This documents the current behavior: you can register a unit with a name
+    that shadows a global alias. The registered unit takes precedence in
+    ur.get_unit() and ur.Quantity(), but Unit("alias_name") still resolves
+    to the canonical unit via global alias resolution.
+    """
+    ur = UnitRegistry()
+
+    # "deg" is a built-in alias for "degree"
+    # Registering a unit named "deg" is allowed (no collision check against aliases)
+    ur.register_unit(unit="deg", composition="m", factor=1.0)
+
+    # The instance-registered unit is accessible
+    assert ur.deg.name == "deg"
+    assert ur.deg.dimensions == ur.m.dimensions  # It's a length unit now
+
+    # ur.get_unit returns the instance-registered unit
+    assert ur.get_unit("deg").name == "deg"
+    assert ur.get_unit("deg").dimensions == ur.m.dimensions
+
+    # ur.Quantity uses instance-registered unit
+    q = ur.Quantity(1, "deg")
+    assert q.units.dimensions == ur.m.dimensions
+
+    # But Unit("deg") still resolves via global alias to "degree" (angle)
+    from ansys.units import Unit
+
+    global_deg = Unit("deg")
+    assert global_deg.name == "degree"  # Resolved via alias
+
+
+def test_register_unit_does_not_detect_equivalent_factor():
+    """
+    Test that collision check is name-only, not factor-based.
+
+    Two units with the same composition and factor but different names can both be
+    registered. No semantic equivalence check is performed.
+    """
+    ur = UnitRegistry()
+
+    # Register two units that are semantically identical (same as Joule)
+    ur.register_unit(unit="myjoule", composition="N m", factor=1)
+    ur.register_unit(unit="yourjoule", composition="N m", factor=1)
+
+    # Both exist and have the same SI scaling factor
+    assert ur.myjoule.si_scaling_factor == pytest.approx(ur.yourjoule.si_scaling_factor)
+    assert ur.myjoule.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
+
+
+def test_register_unit_does_not_detect_equivalent_offset():
+    """
+    Test that collision check doesn't consider SI offset equivalence.
+
+    Note: register_unit only supports factor, not offset. This test confirms
+    that even if two units have the same effective SI conversion, they can
+    both be registered as long as their names differ.
+    """
+    ur = UnitRegistry()
+
+    # Register units with different factors - both allowed despite potential overlap
+    ur.register_unit(unit="mymeter", composition="m", factor=1)
+    ur.register_unit(unit="alsometer", composition="m", factor=1)
+
+    # Both units are functionally identical to "m"
+    assert ur.mymeter.si_scaling_factor == pytest.approx(ur.m.si_scaling_factor)
+    assert ur.alsometer.si_scaling_factor == pytest.approx(ur.m.si_scaling_factor)
+
+
+def test_get_unit_does_not_resolve_global_aliases():
+    """
+    Test that get_unit doesn't resolve global aliases for non-registered units.
+
+    get_unit checks instance-registered units, then falls back to built-in base/derived
+    units, but does NOT resolve aliases.
+    """
+    ur = UnitRegistry()
+
+    # "deg" is a global alias for "degree", but get_unit won't find it
+    # because it only checks instance-registered and built-in (base/derived)
+    with pytest.raises(AttributeError, match="not found"):
+        ur.get_unit("deg")
+
+    # "degree" (the canonical name) is a built-in derived unit
+    unit = ur.get_unit("degree")
+    assert unit.name == "degree"
+
+
+def test_register_unit_name_check_is_case_sensitive():
+    """
+    Test that the name collision check is case-sensitive.
+
+    'M' (mega) and 'm' (meter) are different names.
+    """
+    ur = UnitRegistry()
+
+    # 'm' is a built-in base unit (meter)
+    with pytest.raises(UnitNameAlreadyRegistered):
+        ur.register_unit(unit="m", composition="ft", factor=1)
+
+    # 'M' is not a built-in unit name (it's a multiplier prefix), so this succeeds
+    # Note: This may or may not be desirable behavior depending on use case
+    ur.register_unit(unit="M", composition="m", factor=1e6)
+    assert ur.M.si_scaling_factor == pytest.approx(1e6)
+
+
+def test_equivalent_compositions_same_dimensions():
+    """
+    Test that equivalent compositions produce units with same dimensions.
+
+    This confirms that while name collision isn't checked semantically, the resulting
+    units do have correct dimensions.
+    """
+    ur = UnitRegistry()
+
+    # N m and W s are equivalent energy units
+    ur.register_unit(unit="energy_nm", composition="N m", factor=1)
+    ur.register_unit(unit="energy_ws", composition="W s", factor=1)
+    ur.register_unit(unit="energy_kgm2s2", composition="kg m^2 s^-2", factor=1)
+
+    # All should have same dimensions as Joule
+    assert ur.energy_nm.dimensions == ur.J.dimensions
+    assert ur.energy_ws.dimensions == ur.J.dimensions
+    assert ur.energy_kgm2s2.dimensions == ur.J.dimensions
+
+    # All should have same SI scaling factor
+    assert ur.energy_nm.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
+    assert ur.energy_ws.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)
+    assert ur.energy_kgm2s2.si_scaling_factor == pytest.approx(ur.J.si_scaling_factor)

--- a/tests/test_unit_registry.py
+++ b/tests/test_unit_registry.py
@@ -27,7 +27,7 @@ import pytest
 
 from ansys.units import Unit, UnitRegistry
 from ansys.units._constants import _base_units
-from ansys.units.unit_registry import UnitAlreadyRegistered
+from ansys.units.unit_registry import UnitNameAlreadyRegistered
 
 
 def test_default_units():
@@ -94,11 +94,12 @@ def test_additional_units():
 
 def test_immutability():
     ur = UnitRegistry()
-    with pytest.raises(UnitAlreadyRegistered):
+    with pytest.raises(UnitNameAlreadyRegistered):
         ur.m = Unit("ft")
 
 
 def test_error_message():
-    e1 = UnitAlreadyRegistered("kg")
-    expected_str = "Unable to override `kg` it has already been registered."
+    # Test the new exception name
+    e1 = UnitNameAlreadyRegistered("kg")
+    expected_str = "Unable to register `kg`: a unit with this name already exists."
     assert str(e1) == expected_str


### PR DESCRIPTION
This pull request introduces significant improvements to the `UnitRegistry` class, focusing on more flexible and robust custom unit registration, improved string-based lookup, and clearer error handling for unit name collisions. The documentation and tests are updated to reflect these changes, making it easier for users to register and access custom units both at construction and after instantiation.

**Key changes:**

### Custom Unit Registration & Lookup

* Added a `custom_units` parameter to the `UnitRegistry` constructor, allowing users to register custom units at the time of registry creation using a list of dictionaries. This enables more convenient and declarative unit setup. [[1]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL57-R64) [[2]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efR73-R80) [[3]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efR89) [[4]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efR124-R132)
* Introduced the `get_unit` method and a `Quantity` method on `UnitRegistry` for string-based lookup and creation of quantities using custom units, improving usability and consistency.

### Name Collision & Error Handling

* Replaced the `UnitAlreadyRegistered` exception with a more specific `UnitNameAlreadyRegistered` exception, used consistently throughout the codebase for name-only collision detection (i.e., duplicate unit names, including built-ins). The check is now explicitly name-based, allowing equivalent units with different names. [[1]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL91-R107) [[2]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL138-R238) [[3]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL156-R266) [[4]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL168-R281) [[5]](diffhunk://#diff-eeab04bfcabfc3c6c4977cf37d389b3d61b351fc95bbf6bbfb4e42ac165c42efL248-R366) [[6]](diffhunk://#diff-289f49ac1b5e568fb18c219604cf27f999f8b85216f2c3b05007cd3c7181a31eL26-R26) [[7]](diffhunk://#diff-289f49ac1b5e568fb18c219604cf27f999f8b85216f2c3b05007cd3c7181a31eL42-R50) [[8]](diffhunk://#diff-8b25c0e33fe196b0cc0788ee9cb79bfedcb5ebf2ff8faef7757ac7c68e0b2c21L13-R16)

### Documentation Updates

* Expanded and reorganized documentation to clearly explain how to register custom units at construction and after instantiation, how string-based lookup works, and how instance isolation and name collision detection operate. Examples and notes have been added for clarity. [[1]](diffhunk://#diff-edf60f74872f42e56ed597969dcc10580058c84dcaaa5a6faf75ac27897b6927L4-R97) [[2]](diffhunk://#diff-9bbd542d596c522d1ef8588f7a24e3318825a376f8691e0d1885da4acca49788L266-R291)

---

These changes make it easier and safer to extend the unit system with custom definitions, while providing clear feedback and documentation for users.