### PR TITLE
CHORE: Have concrete classes for Scalar and Vector Variable Descriptor classes.

### DIFF
--- a/src/ansys/units/variable_descriptor/variable_descriptor.py
+++ b/src/ansys/units/variable_descriptor/variable_descriptor.py
@@ -66,11 +66,14 @@ class VariableDescriptor(Generic[QuantityKindT]):
 @dataclass(frozen=True, unsafe_hash=True)
 class ScalarVariableDescriptor(VariableDescriptor[Literal[QuantityKind.SCALAR]]):
     """Concrete class for scalar variables supporting runtime isinstance checks."""
+
     pass
+
 
 @dataclass(frozen=True, unsafe_hash=True)
 class VectorVariableDescriptor(VariableDescriptor[Literal[QuantityKind.VECTOR]]):
     """Concrete class for vector variables supporting runtime isinstance checks."""
+
     pass
 
 

--- a/src/ansys/units/variable_descriptor/variable_descriptor.py
+++ b/src/ansys/units/variable_descriptor/variable_descriptor.py
@@ -63,12 +63,15 @@ class VariableDescriptor(Generic[QuantityKindT]):
         object.__setattr__(self, "name", _validate_and_transform_variable(name))
 
 
-ScalarVariableDescriptor = VariableDescriptor[
-    Literal[QuantityKind.SCALAR]
-]  #: Type alias for scalar variables
-VectorVariableDescriptor = VariableDescriptor[
-    Literal[QuantityKind.VECTOR]
-]  #: Type alias for vector variables
+@dataclass(frozen=True, unsafe_hash=True)
+class ScalarVariableDescriptor(VariableDescriptor[Literal[QuantityKind.SCALAR]]):
+    """Concrete class for scalar variables supporting runtime isinstance checks."""
+    pass
+
+@dataclass(frozen=True, unsafe_hash=True)
+class VectorVariableDescriptor(VariableDescriptor[Literal[QuantityKind.VECTOR]]):
+    """Concrete class for vector variables supporting runtime isinstance checks."""
+    pass
 
 
 def _validate_and_transform_variable(variable: str) -> str:


### PR DESCRIPTION
`VectorVariableDescriptor` and `ScalarVariableDescriptor` were pure type aliases with no runtime distinction — both were just `VariableDescriptor` instances. Hence the earlier design does not support strict runtime scalar/vector discrimination via `isinstance`.

Now:
1. Runtime strict type checking will be possible using both `ScalarVariableDescriptor` and `VectorVariableDescriptor`.
2. `ScalarVariableDescriptor` and `VectorVariableDescriptor` are concrete classes that inherit directly from `VariableDescriptor`. They retain all functionality, including `@dataclass(frozen=True, unsafe_hash=True)`, the descriptor behavior `(__set_name__)`, and compatibility with your existing validation functions.
3. Static analysis tools will still correctly understand that a `VectorVariableDescriptor` is a specialized form of `VariableDescriptor` tied to the vector literal type.